### PR TITLE
Fix `DriveBrowser` toolbar buttons

### DIFF
--- a/schema/drives-file-browser.json
+++ b/schema/drives-file-browser.json
@@ -2,7 +2,6 @@
   "title": "Jupyter Drives Settings",
   "description": "jupyter-drives settings.",
   "jupyter.lab.toolbars": {
-    "displayMode": "icon",
     "DriveBrowser": [
       {
         "name": "new-launcher",

--- a/schema/drives-file-browser.json
+++ b/schema/drives-file-browser.json
@@ -2,30 +2,36 @@
   "title": "Jupyter Drives Settings",
   "description": "jupyter-drives settings.",
   "jupyter.lab.toolbars": {
+    "displayMode": "icon",
     "DriveBrowser": [
       {
         "name": "new-launcher",
         "command": "launcher:create",
+        "label": "",
         "rank": 1
       },
       {
         "name": "new-directory",
         "command": "filebrowser:create-new-directory",
+        "label": "",
         "rank": 10
       },
-      { "name": "uploader", "rank": 20 },
+      { "name": "uploader", "label": "", "rank": 20 },
       {
         "name": "refresh",
         "command": "filebrowser:refresh",
+        "label": "",
         "rank": 30
       },
       {
         "name": "toggle-file-filter",
         "command": "filebrowser:toggle-file-filter",
+        "label": "",
         "rank": 40
       },
       {
         "name": "file-name-searcher",
+        "label": "",
         "rank": 50
       }
     ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,6 @@ import {
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { FilenameSearcher, IScore } from '@jupyterlab/ui-components';
 import { CommandRegistry } from '@lumino/commands';
-import { Panel } from '@lumino/widgets';
 
 import { DriveListModel, DriveListView, IDrive } from './drivelistmanager';
 import { DriveIcon, driveBrowserIcon } from './icons';
@@ -203,8 +202,16 @@ const driveFileBrowser: JupyterFrontEndPlugin<void> = {
     // Set attributes when adding the browser to the UI
     driveBrowser.node.setAttribute('role', 'region');
     driveBrowser.node.setAttribute('aria-label', 'Drive Browser Section');
+    driveBrowser.title.icon = driveBrowserIcon;
+    driveBrowser.title.caption = 'Drive File Browser';
+    driveBrowser.id = 'Drive-File-Browser';
 
     void Private.restoreBrowser(driveBrowser, commands, router, tree, labShell);
+
+    app.shell.add(driveBrowser, 'left', { rank: 102, type: 'File Browser' });
+    if (restorer) {
+      restorer.add(driveBrowser, 'drive-file-browser');
+    }
 
     toolbarRegistry.addFactory(
       FILE_BROWSER_FACTORY,
@@ -246,19 +253,6 @@ const driveFileBrowser: JupyterFrontEndPlugin<void> = {
         translator
       )
     );
-
-    // instate Drive Browser Panel
-    const drivePanel = new Panel();
-    drivePanel.title.icon = driveBrowserIcon;
-    drivePanel.title.iconClass = 'jp-sideBar-tabIcon';
-    drivePanel.title.caption = 'Drive File Browser';
-    drivePanel.id = 'Drive-Browser-Panel';
-
-    app.shell.add(drivePanel, 'left', { rank: 102, type: 'File Browser' });
-    drivePanel.addWidget(driveBrowser);
-    if (restorer) {
-      restorer.add(drivePanel, 'drive-sidepanel');
-    }
   }
 };
 


### PR DESCRIPTION
Fix the toolbar buttons from the `DriveBrowser`, as they were initially displayed with the labels next to their icons. Also, the redundant use of a `Panel` instance was eliminated, when instating the `DriveBrowser`. This PR continues on the work in: #18.