### PR TITLE
Add content retrieval logic 

### DIFF
--- a/jupyter_drives/handlers.py
+++ b/jupyter_drives/handlers.py
@@ -69,17 +69,17 @@ class ContentsJupyterDrivesHandler(JupyterDrivesAPIHandler):
         return super().initialize(logger, manager)
     
     @tornado.web.authenticated
-    async def get(self, path: str = "", drive: str = ""):
+    async def get(self, drive: str = "", path: str = ""):
         result = await self._manager.get_contents(drive, path)
         self.finish(result)
 
     @tornado.web.authenticated
-    async def post(self, path: str = "", drive: str = ""):
+    async def post(self, drive: str = "", path: str = ""):
         result = await self._manager.new_file(drive, path)
         self.finish(result)
 
     @tornado.web.authenticated
-    async def patch(self, path: str = "", drive: str = ""):
+    async def patch(self, drive: str = "", path: str = ""):
         body = self.get_json_body()
         result = await self._manager.rename_file(drive, path, **body)
         self.finish(result)

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -193,8 +193,8 @@ class JupyterDrivesManager():
                 # retrieve metadata of object
                 metadata = await obs.head_async(self._content_managers[drive_name], path)
 
-                # for certain media type files, extracted contents need to be read as a byte array and decoded to base64 to be viewable in JupyterLab
-                # the following extesnions correspond to a base64 file format or are of type PDF
+                # for certain media type files, extracted content needs to be read as a byte array and decoded to base64 to be viewable in JupyterLab
+                # the following extensions correspond to a base64 file format or are of type PDF
                 ext = os.path.splitext(path)[1]
                 if ext == '.pdf' or ext == '.svg' or ext == '.tif' or ext == '.tiff' or ext == '.jpg' or ext == '.jpeg' or ext == '.gif' or ext == '.png' or ext == '.bmp' or ext == '.webp':
                     processed_content = base64.b64encode(content).decode("utf-8")

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -88,7 +88,7 @@ class JupyterDrivesManager():
                         "name": result.name,
                         "region": self._config.region_name if self._config.region_name is not None else "eu-north-1",
                         "creation_date": result.extra["creation_date"],
-                        "mounted": "true" if result.name not in self._content_managers else "false",
+                        "mounted": False if result.name not in self._content_managers else True,
                         "provider": self._config.provider
                     }
                 )

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -162,17 +162,12 @@ class JupyterDrivesManager():
             drive_name: name of drive to get the contents of
             path: path to file or directory (empty string for root listing)
         """
-        print('!!!!!!!!!!!!!!!!!!!', drive_name, 'path: ', path)
         if path == '/':
             path = ''
-        drive_name = 'jupyter-drives-test-bucket-1'
         try :
             currentObject = os.path.basename(path) if os.path.basename(path) is not None else ''
-            print('currentObject: ', currentObject)
             # check if we are listing contents of a directory
             if currentObject.find('.') == -1:
-                print('in if')
-                print('store: ', self._content_managers)
                 data = []
                 # using Arrow lists as they are recommended for large results
                 # sream will be an async iterable of RecordBatch
@@ -201,7 +196,6 @@ class JupyterDrivesManager():
                     "last_modified": metadata["last_modified"].isoformat(),
                     "size": metadata["size"]
                 }
-            print(data)
             response = {
                 "data": data
             }

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -174,7 +174,7 @@ class JupyterDrivesManager():
             # stream will be an async iterable of RecordBatch
             stream = obs.list(self._content_managers[drive_name], path, chunk_size=100, return_arrow=True)
             async for batch in stream:
-                # check once if we are dealing with a directory
+                # if content exists we are dealing with a directory
                 if isDir is False and batch: 
                     isDir = True
                     emptyDir = False
@@ -194,6 +194,7 @@ class JupyterDrivesManager():
                 obj = await obs.get_async(self._content_managers[drive_name], path)
                 stream = obj.stream(min_chunk_size=5 * 1024 * 1024) # 5MB sized chunks
                 async for buf in stream: 
+                    # if content exists we are dealing with a file
                     if emptyDir is True and buf:
                         emptyDir = False
                     content += buf

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -216,7 +216,7 @@ class JupyterDrivesManager():
                     "size": metadata["size"]
                 }
 
-            # dealing with the case of an empty directory 
+            # dealing with the case of an empty directory, making sure it is not an empty file
             # TO DO: find better way to check
             if emptyDir is True: 
                 ext_list = ['.R', '.bmp', '.csv', '.gif', '.html', '.ipynb', '.jl', '.jpeg', '.jpg', '.json', '.jsonl', '.md', '.ndjson', '.pdf', '.png', '.py', '.svg', '.tif', '.tiff', '.tsv', '.txt', '.webp', '.yaml', '.yml']

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -218,8 +218,12 @@ class JupyterDrivesManager():
 
             # dealing with the case of an empty directory 
             # TO DO: find better way to check
-            if emptyDir is True and os.path.basename(path).find('.') == -1:
-                data = []
+            if emptyDir is True: 
+                ext_list = ['.R', '.bmp', '.csv', '.gif', '.html', '.ipynb', '.jl', '.jpeg', '.jpg', '.json', '.jsonl', '.md', '.ndjson', '.pdf', '.png', '.py', '.svg', '.tif', '.tiff', '.tsv', '.txt', '.webp', '.yaml', '.yml']
+                object_name = os.path.basename(path)
+                # if object doesn't contain . or doesn't end in one of the registered extensions
+                if object_name.find('.') == -1 or ext_list.count(os.path.splitext(object_name)[1]) == 0:
+                    data = []
 
             response = {
                 "data": data

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -166,6 +166,7 @@ class JupyterDrivesManager():
             path = ''
         try :
             currentObject = os.path.basename(path) if os.path.basename(path) is not None else ''
+
             # check if we are listing contents of a directory
             if currentObject.find('.') == -1:
                 data = []
@@ -192,7 +193,7 @@ class JupyterDrivesManager():
                 metadata = await obs.head_async(self._content_managers[drive_name], path)
                 data = {
                     "path": path, 
-                    "content": content,
+                    "content": content.decode("utf-8"),
                     "last_modified": metadata["last_modified"].isoformat(),
                     "size": metadata["size"]
                 }

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -156,7 +156,7 @@ class JupyterDrivesManager():
         
         return
     
-    async def get_contents(self, drive_name, path, special_type=False):
+    async def get_contents(self, drive_name, path):
         """Get contents of a file or directory.
 
         Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "obstore>=0.2.0,<0.3",
+    "pyarrow>=18.0.0,<19.0.0",
     "jupyter_server>=2.14.2,<3",
     "s3contents>=0.11.1,<0.12.0",
     "apache-libcloud>=3.8.0, <4",

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -3,7 +3,6 @@
 
 import { Signal, ISignal } from '@lumino/signaling';
 import { Contents, ServerConnection } from '@jupyterlab/services';
-import { PathExt } from '@jupyterlab/coreutils';
 import { IDriveInfo } from './token';
 import { getContents, mountDrive } from './requests';
 
@@ -208,21 +207,7 @@ export class Drive implements Contents.IDrive {
         }
       }
 
-      const resp = await getContents(currentDrive.name, { path: '' });
-      console.log('resp: ', resp);
-
-      data = {
-        name: PathExt.basename(localPath),
-        path: PathExt.basename(localPath),
-        last_modified: '',
-        created: '',
-        content: [],
-        format: 'json',
-        mimetype: '',
-        size: undefined,
-        writable: true,
-        type: 'directory'
-      };
+      data = await getContents(currentDrive.name, { path: '' });
     } else {
       const drivesList: Contents.IModel[] = [];
       for (const drive of this._drivesList) {

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -5,7 +5,7 @@ import { Signal, ISignal } from '@lumino/signaling';
 import { Contents, ServerConnection } from '@jupyterlab/services';
 import { PathExt } from '@jupyterlab/coreutils';
 import { IDriveInfo } from './token';
-import { mountDrive } from './requests';
+import { getContents, mountDrive } from './requests';
 
 let data: Contents.IModel = {
   name: '',
@@ -205,6 +205,9 @@ export class Drive implements Contents.IDrive {
           console.log(e);
         }
       }
+
+      const resp = await getContents(currentDrive.name, { path: '' });
+      console.log('resp: ', resp);
 
       data = {
         name: PathExt.basename(localPath),

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -641,7 +641,7 @@ export class Drive implements Contents.IDrive {
           this._registeredFileTypes[extension] = {
             fileType: fileType.name,
             fileMimeTypes: [...fileType.mimeTypes],
-            fileFormat: fileType.fileFormat ? fileType.fileFormat : ''
+            fileFormat: fileType.fileFormat ?? ''
           };
         }
       });

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -192,15 +192,17 @@ export class Drive implements Contents.IDrive {
       }
 
       // extract current drive name
-      const currentDrive = this.drivesList.filter(x => x.name === localPath)[0];
+      const currentDrive = this._drivesList.filter(
+        x => x.name === localPath
+      )[0];
       // when accessed the first time, mount drive
-      if (!currentDrive.mounted) {
+      if (currentDrive.mounted === false) {
         try {
           await mountDrive(localPath, {
             provider: currentDrive.provider,
             region: currentDrive.region
           });
-          currentDrive.mounted = true;
+          this._drivesList.filter(x => x.name === localPath)[0].mounted = true;
         } catch (e) {
           console.log(e);
         }

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -194,19 +194,18 @@ export class Drive implements Contents.IDrive {
     localPath: string,
     options?: Contents.IFetchOptions
   ): Promise<Contents.IModel> {
-    const relativePath = '';
+    let relativePath = '';
     console.log('GET localpath: ', localPath);
     if (localPath !== '') {
-      // if (localPath.includes(this.name)) {
-      //   relativePath = localPath.split(this.name + '/')[1];
-      // } else {
-      //   relativePath = localPath;
-      // }
-
       // extract current drive name
       const currentDrive = this._drivesList.filter(
-        x => x.name === localPath
+        x =>
+          x.name ===
+          (localPath.indexOf('/') !== -1
+            ? localPath.substring(0, localPath.indexOf('/'))
+            : localPath)
       )[0];
+
       // when accessed the first time, mount drive
       if (currentDrive.mounted === false) {
         try {
@@ -220,11 +219,19 @@ export class Drive implements Contents.IDrive {
         }
       }
 
+      // eliminate drive name from path
+      relativePath =
+        localPath.indexOf('/') !== -1
+          ? localPath.substring(localPath.indexOf('/') + 1)
+          : '';
+
       data = await getContents(currentDrive.name, {
-        path: '',
+        path: relativePath,
         registeredFileTypes: this._registeredFileTypes
       });
     } else {
+      // retriving list of contents from root
+      // in our case: list available drives
       const drivesList: Contents.IModel[] = [];
       for (const drive of this._drivesList) {
         drivesList.push({

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -571,7 +571,11 @@ export class Drive implements Contents.IDrive {
    *   checkpoint is created.
    */
   createCheckpoint(path: string): Promise<Contents.ICheckpointModel> {
-    return Promise.reject('Repository is read only');
+    const emptyCheckpoint: Contents.ICheckpointModel = {
+      id: '',
+      last_modified: ''
+    };
+    return Promise.resolve(emptyCheckpoint);
   }
 
   /**

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -195,7 +195,6 @@ export class Drive implements Contents.IDrive {
     options?: Contents.IFetchOptions
   ): Promise<Contents.IModel> {
     let relativePath = '';
-    console.log('GET localpath: ', localPath);
     if (localPath !== '') {
       // extract current drive name
       const currentDrive = this._drivesList.filter(
@@ -261,7 +260,6 @@ export class Drive implements Contents.IDrive {
         type: 'directory'
       };
     }
-    console.log('GET: ', relativePath);
 
     Contents.validateContentsModel(data);
     return data;

--- a/src/index.ts
+++ b/src/index.ts
@@ -224,6 +224,9 @@ const driveFileBrowser: JupyterFrontEndPlugin<void> = {
 
     app.serviceManager.contents.addDrive(drive);
 
+    // get registered file types
+    drive.getRegisteredFileTypes(app);
+
     // Manually restore and load the drive file browser.
     const driveBrowser = fileBrowserFactory.createFileBrowser('drivebrowser', {
       auto: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,8 +172,8 @@ const drivesListProvider: JupyterFrontEndPlugin<IDriveInfo[]> = {
           mounted: drive.mounted
         });
       }
-    } catch {
-      console.log('Failed loading available drives list.');
+    } catch (error) {
+      console.log('Failed loading available drives list, with error: ', error);
     }
     return drives;
   }

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -66,48 +66,71 @@ export async function getContents(
   );
 
   if (response.data) {
-    const fileList: IContentsList = {};
+    // listing the contents of a directory
+    if (options.path.indexOf('.') === -1) {
+      const fileList: IContentsList = {};
 
-    response.data.forEach((row: any) => {
-      // check if we are dealing with files inside a subfolder
-      if (row.path !== options.path && row.path !== options.path + '/') {
-        // extract object name from path
-        const fileName = row.path
-          .replace(options.path ? options.path + '/' : '', '')
-          .split('/')[0];
+      response.data.forEach((row: any) => {
+        // check if we are dealing with files inside a subfolder
+        if (row.path !== options.path && row.path !== options.path + '/') {
+          // extract object name from path
+          const fileName = row.path
+            .replace(options.path ? options.path + '/' : '', '')
+            .split('/')[0];
 
-        const [fileType, fileMimeType, fileFormat] = getFileType(
-          PathExt.extname(PathExt.basename(fileName)),
-          options.registeredFileTypes
-        );
+          const [fileType, fileMimeType, fileFormat] = getFileType(
+            PathExt.extname(PathExt.basename(fileName)),
+            options.registeredFileTypes
+          );
 
-        fileList[fileName] = fileList[fileName] ?? {
-          name: fileName,
-          path: driveName + '/' + row.path,
-          last_modified: row.last_modified,
-          created: '',
-          content: !fileName.split('.')[1] ? [] : null,
-          format: fileFormat as Contents.FileFormat,
-          mimetype: fileMimeType,
-          size: row.size,
-          writable: true,
-          type: fileType
-        };
-      }
-    });
+          fileList[fileName] = fileList[fileName] ?? {
+            name: fileName,
+            path: driveName + '/' + row.path,
+            last_modified: row.last_modified,
+            created: '',
+            content: !fileName.split('.')[1] ? [] : null,
+            format: fileFormat as Contents.FileFormat,
+            mimetype: fileMimeType,
+            size: row.size,
+            writable: true,
+            type: fileType
+          };
+        }
+      });
 
-    data = {
-      name: options.path ? PathExt.basename(options.path) : '',
-      path: options.path ? options.path + '/' : '',
-      last_modified: '',
-      created: '',
-      content: Object.values(fileList),
-      format: 'json',
-      mimetype: '',
-      size: undefined,
-      writable: true,
-      type: 'directory'
-    };
+      data = {
+        name: options.path ? PathExt.basename(options.path) : '',
+        path: options.path ? options.path + '/' : '',
+        last_modified: '',
+        created: '',
+        content: Object.values(fileList),
+        format: 'json',
+        mimetype: '',
+        size: undefined,
+        writable: true,
+        type: 'directory'
+      };
+    }
+    // getting the contents of a file
+    else {
+      const [fileType, fileMimeType, fileFormat] = getFileType(
+        PathExt.extname(PathExt.basename(options.path)),
+        options.registeredFileTypes
+      );
+
+      data = {
+        name: PathExt.basename(options.path),
+        path: driveName + '/' + response.data.path,
+        last_modified: response.data.last_modified,
+        created: '',
+        content: response.data.content,
+        format: fileFormat as Contents.FileFormat,
+        mimetype: fileMimeType,
+        size: response.data.size,
+        writable: true,
+        type: fileType
+      };
+    }
   }
 
   return data;

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -69,25 +69,31 @@ export async function getContents(
     const fileList: IContentsList = {};
 
     response.data.forEach((row: any) => {
-      const fileName = PathExt.basename(row.path);
+      // check if we are dealing with files inside a subfolder
+      if (row.path !== options.path && row.path !== options.path + '/') {
+        // extract object name from path
+        const fileName = row.path
+          .replace(options.path ? options.path + '/' : '', '')
+          .split('/')[0];
 
-      const [fileType, fileMimeType, fileFormat] = getFileType(
-        PathExt.extname(PathExt.basename(fileName)),
-        options.registeredFileTypes
-      );
+        const [fileType, fileMimeType, fileFormat] = getFileType(
+          PathExt.extname(PathExt.basename(fileName)),
+          options.registeredFileTypes
+        );
 
-      fileList[fileName] = fileList[fileName] ?? {
-        name: fileName,
-        path: driveName + '/' + row.path,
-        last_modified: row.last_modified,
-        created: '',
-        content: !fileName.split('.')[1] ? [] : null,
-        format: fileFormat as Contents.FileFormat,
-        mimetype: fileMimeType,
-        size: row.size,
-        writable: true,
-        type: fileType
-      };
+        fileList[fileName] = fileList[fileName] ?? {
+          name: fileName,
+          path: driveName + '/' + row.path,
+          last_modified: row.last_modified,
+          created: '',
+          content: !fileName.split('.')[1] ? [] : null,
+          format: fileFormat as Contents.FileFormat,
+          mimetype: fileMimeType,
+          size: row.size,
+          writable: true,
+          type: fileType
+        };
+      }
     });
 
     data = {

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -3,8 +3,11 @@ import { Contents } from '@jupyterlab/services';
 import { PathExt } from '@jupyterlab/coreutils';
 
 import { requestAPI } from './handler';
-import { getFileType, IRegisteredFileTypes } from './token';
+import { getFileType, IRegisteredFileTypes, IContentsList } from './token';
 
+/**
+ * The data contents model.
+ */
 let data: Contents.IModel = {
   name: '',
   path: '',
@@ -18,13 +21,9 @@ let data: Contents.IModel = {
   type: ''
 };
 
-interface IContentsList {
-  [fileName: string]: Contents.IModel;
-}
-
 /**
  * Fetch the list of available drives.
- * @returns list of drives
+ * @returns The list of available drives.
  */
 export async function getDrivesList() {
   return await requestAPI<any>('drives', 'GET');
@@ -33,6 +32,8 @@ export async function getDrivesList() {
 /**
  * Mount a drive by establishing a connection with it.
  * @param driveName
+ * @param options.provider The provider of the drive to be mounted.
+ * @param options.region The region of the drive to be mounted.
  */
 export async function mountDrive(
   driveName: string,
@@ -46,6 +47,15 @@ export async function mountDrive(
   return await requestAPI<any>('drives', 'POST', body);
 }
 
+/**
+ * Get contents of a directory or retrieve contents of a specific file.
+ *
+ * @param driveName
+ * @param options.path The path of object to be retrived
+ * @param options.path The list containing all registered file types.
+ *
+ * @returns A promise which resolves with the contents model.
+ */
 export async function getContents(
   driveName: string,
   options: { path: string; registeredFileTypes: IRegisteredFileTypes }

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -64,10 +64,11 @@ export async function getContents(
     'drives/' + driveName + '/' + options.path,
     'GET'
   );
+  const isDir: boolean = PathExt.extname(options.path) === '';
 
   if (response.data) {
     // listing the contents of a directory
-    if (options.path.indexOf('.') === -1) {
+    if (isDir) {
       const fileList: IContentsList = {};
 
       response.data.forEach((row: any) => {

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -64,7 +64,8 @@ export async function getContents(
     'drives/' + driveName + '/' + options.path,
     'GET'
   );
-  const isDir: boolean = PathExt.extname(options.path) === '';
+  // checking if we are dealing with a directory or a file
+  const isDir: boolean = response.data.length !== undefined;
 
   if (response.data) {
     // listing the contents of a directory

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -1,4 +1,5 @@
 import { ReadonlyJSONObject } from '@lumino/coreutils';
+
 import { requestAPI } from './handler';
 
 /**
@@ -23,4 +24,14 @@ export async function mountDrive(
     region: options.region
   };
   return await requestAPI<any>('drives', 'POST', body);
+}
+
+export async function getContents(
+  driveName: string,
+  options: { path: string }
+) {
+  return await requestAPI<any>(
+    'drives/' + driveName + '/' + options.path,
+    'GET'
+  );
 }

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,4 +1,5 @@
 import { Token } from '@lumino/coreutils';
+import { Contents } from '@jupyterlab/services';
 
 /**
  * A token for the plugin that provides the list of drives.
@@ -31,6 +32,13 @@ export interface IDriveInfo {
    * Whether a content manager for the drive was already set up in the backend (true) or not (false).
    */
   mounted: boolean;
+}
+
+/**
+ * An interface for storing the contents of a directory.
+ */
+export interface IContentsList {
+  [fileName: string]: Contents.IModel;
 }
 
 /**

--- a/src/token.ts
+++ b/src/token.ts
@@ -32,3 +32,41 @@ export interface IDriveInfo {
    */
   mounted: boolean;
 }
+
+/**
+ * An interface that stores the registered file type, mimetype and format for each file extension.
+ */
+export interface IRegisteredFileTypes {
+  [fileExtension: string]: {
+    fileType: string;
+    fileMimeTypes: string[];
+    fileFormat: string;
+  };
+}
+
+/**
+ * Helping function to define file type, mimetype and format based on file extension.
+ * @param extension file extension (e.g.: txt, ipynb, csv)
+ * @returns
+ */
+export function getFileType(
+  extension: string,
+  registeredFileTypes: IRegisteredFileTypes
+) {
+  let fileType: string = 'text';
+  let fileMimetype: string = 'text/plain';
+  let fileFormat: string = 'text';
+
+  if (registeredFileTypes[extension]) {
+    fileType = registeredFileTypes[extension].fileType;
+    fileMimetype = registeredFileTypes[extension].fileMimeTypes[0];
+    fileFormat = registeredFileTypes[extension].fileFormat;
+  }
+
+  // the file format for notebooks appears as json, but should be text
+  if (extension === '.ipynb') {
+    fileFormat = 'text';
+  }
+
+  return [fileType, fileMimetype, fileFormat];
+}


### PR DESCRIPTION
This PR adds the logic to list the contents of a drive and retrieve the contents of an individual file. 

In order to properly deal with all types of content, the extension also retrieves all the registered `JupyterLab` file types and their corresponding formats and mimetypes. For certain files media types, the content is decoded differently in the backend.