### PR TITLE
Add functionalities to manipulate content

### DIFF
--- a/jupyter_drives/handlers.py
+++ b/jupyter_drives/handlers.py
@@ -84,6 +84,12 @@ class ContentsJupyterDrivesHandler(JupyterDrivesAPIHandler):
         result = await self._manager.rename_file(drive, path, **body)
         self.finish(result)
 
+    @tornado.web.authenticated
+    async def put(self, drive: str = "", path: str = ""):
+        body = self.get_json_body()
+        result = await self._manager.save_file(drive, path, **body)
+        self.finish(result)
+
 handlers = [
     ("drives", ListJupyterDrivesHandler)
 ]

--- a/jupyter_drives/handlers.py
+++ b/jupyter_drives/handlers.py
@@ -95,6 +95,11 @@ class ContentsJupyterDrivesHandler(JupyterDrivesAPIHandler):
         result = await self._manager.delete_file(drive, path)
         self.finish(result)
 
+    @tornado.web.authenticated
+    async def head(self, drive: str = "", path: str = ""):
+        result = await self._manager.check_file(drive, path)
+        self.finish(result)
+
 handlers = [
     ("drives", ListJupyterDrivesHandler)
 ]

--- a/jupyter_drives/handlers.py
+++ b/jupyter_drives/handlers.py
@@ -89,6 +89,11 @@ class ContentsJupyterDrivesHandler(JupyterDrivesAPIHandler):
         body = self.get_json_body()
         result = await self._manager.save_file(drive, path, **body)
         self.finish(result)
+    
+    @tornado.web.authenticated
+    async def delete(self, drive: str = "", path: str = ""):
+        result = await self._manager.delete_file(drive, path)
+        self.finish(result)
 
 handlers = [
     ("drives", ListJupyterDrivesHandler)

--- a/jupyter_drives/handlers.py
+++ b/jupyter_drives/handlers.py
@@ -87,7 +87,10 @@ class ContentsJupyterDrivesHandler(JupyterDrivesAPIHandler):
     @tornado.web.authenticated
     async def put(self, drive: str = "", path: str = ""):
         body = self.get_json_body()
-        result = await self._manager.save_file(drive, path, **body)
+        if 'content' in body: 
+            result = await self._manager.save_file(drive, path, **body)
+        elif 'to_path' in body: 
+            result = await self._manager.copy_file(drive, path, **body)
         self.finish(result)
     
     @tornado.web.authenticated

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -281,6 +281,9 @@ class JupyterDrivesManager():
             drive_name: name of drive where file exists
             path: path where new content should be saved
             content: content of object
+            options_format: format of content (as sent through contents manager request)
+            content_format: format of content (as defined by the registered file formats in JupyterLab)
+            content_type: type of content (as defined by the registered file types in JupyterLab)
         """
         data = {}
         try: 

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -247,7 +247,6 @@ class JupyterDrivesManager():
         Args:
             drive_name: name of drive where the new content is created
             path: path where new content should be created
-            content: content of object
         """
         data = {}
         try:
@@ -289,8 +288,8 @@ class JupyterDrivesManager():
             path = path.strip('/')
 
             if options_format == 'json':
-                formattedContent = json.dumps(content, indent=2)
-                formattedContent = formattedContent.encode("utf-8")
+                formatted_content = json.dumps(content, indent=2)
+                formatted_content = formatted_content.encode("utf-8")
             elif options_format == 'base64' and (content_format == 'base64' or content_type == 'PDF'):
                 # transform base64 encoding to a UTF-8 byte array for saving or storing
                 byte_characters = base64.b64decode(content)
@@ -302,14 +301,14 @@ class JupyterDrivesManager():
                     byte_arrays.append(byte_array)
                 
                 # combine byte arrays and wrap in a BytesIO object 
-                formattedContent = BytesIO(b"".join(byte_arrays))
-                formattedContent.seek(0)  # reset cursor for any further reading
+                formatted_content = BytesIO(b"".join(byte_arrays))
+                formatted_content.seek(0)  # reset cursor for any further reading
             elif options_format == 'text':
-                formattedContent = content.encode("utf-8")
+                formatted_content = content.encode("utf-8")
             else:
-                formattedContent = content
+                formatted_content = content
 
-            await obs.put_async(self._content_managers[drive_name], path, formattedContent, mode = "overwrite")
+            await obs.put_async(self._content_managers[drive_name], path, formatted_content, mode = "overwrite")
             metadata = await obs.head_async(self._content_managers[drive_name], path)
 
             data = {
@@ -335,6 +334,7 @@ class JupyterDrivesManager():
         Args:
             drive_name: name of drive where file is located
             path: path of file
+            new_path: path of new file name
         """
         data = {}
         try: 

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -387,19 +387,17 @@ class JupyterDrivesManager():
             drive_name: name of drive where object exists
             path: path where content is located
         """
-        result = False
         try: 
             # eliminate leading and trailing backslashes
             path = path.strip('/')
             await obs.head_async(self._content_managers[drive_name], path)
-            result = True
         except Exception:
-           pass
+           raise tornado.web.HTTPError(
+            status_code= httpx.codes.NOT_FOUND,
+            reason="Object does not already exist within drive.",
+            )
         
-        response = {
-            result: result
-        }
-        return response
+        return 
     
     async def copy_file(self, drive_name, path, to_path):
         """Save file with new content.

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -314,6 +314,26 @@ class JupyterDrivesManager():
             path: path of file
         """
         print('Rename file function called.')
+
+    async def delete_file(self, drive_name, path):
+        """Delete an object.
+        
+        Args:
+            drive_name: name of drive where object exists
+            path: path where content is located
+        """
+        try: 
+            # eliminate leading and trailing backslashes
+            path = path.strip('/')
+            await obs.delete_async(self._content_managers[drive_name], path)
+
+        except Exception as e:
+            raise tornado.web.HTTPError(
+            status_code= httpx.codes.BAD_REQUEST,
+            reason=f"The following error occured when deleting the object: {e}",
+            )
+        
+        return
     
     async def _call_provider(
         self,

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -338,6 +338,27 @@ class JupyterDrivesManager():
         
         return
     
+    async def check_file(self, drive_name, path):
+        """Check if an object already exists within a drive.
+        
+        Args:
+            drive_name: name of drive where object exists
+            path: path where content is located
+        """
+        result = False
+        try: 
+            # eliminate leading and trailing backslashes
+            path = path.strip('/')
+            await obs.head_async(self._content_managers[drive_name], path)
+            result = True
+        except Exception:
+           pass
+        
+        response = {
+            result: result
+        }
+        return response
+    
     async def _call_provider(
         self,
         url: str,

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -381,6 +381,38 @@ class JupyterDrivesManager():
         }
         return response
     
+    async def copy_file(self, drive_name, path, to_path):
+        """Save file with new content.
+        
+        Args:
+            drive_name: name of drive where file exists
+            path: path where original content exists
+            to_path: path where object should be copied
+        """
+        data = {}
+        try: 
+            # eliminate leading and trailing backslashes
+            path = path.strip('/')
+
+            await obs.copy_async(self._content_managers[drive_name], path, to_path)
+            metadata = await obs.head_async(self._content_managers[drive_name], to_path)
+
+            data = {
+                "path": to_path,
+                "last_modified": metadata["last_modified"].isoformat(),
+                "size": metadata["size"]
+            }
+        except Exception as e:
+            raise tornado.web.HTTPError(
+            status_code= httpx.codes.BAD_REQUEST,
+            reason=f"The following error occured when copying the: {e}",
+            )
+        
+        response = {
+                "data": data
+            }
+        return response
+    
     async def _call_provider(
         self,
         url: str,

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -165,6 +165,9 @@ class JupyterDrivesManager():
         """
         if path == '/':
             path = ''
+        else: 
+            path = path.strip('/')
+
         try :
             data = []
             isDir = False

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -226,7 +226,7 @@ export class Drive implements Contents.IDrive {
           });
           this._drivesList.filter(x => x.name === localPath)[0].mounted = true;
         } catch (e) {
-          console.log(e);
+          // it will give an error if drive is already mounted
         }
       }
 

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -285,7 +285,6 @@ export class Drive implements Contents.IDrive {
    * @returns A promise which resolves with the created file content when the
    *    file is created.
    */
-
   async newUntitled(
     options: Contents.ICreateOptions = {}
   ): Promise<Contents.IModel> {
@@ -395,29 +394,30 @@ export class Drive implements Contents.IDrive {
    *
    * @returns A promise which resolves when the file is deleted.
    */
-  /*delete(path: string): Promise<void> {
-    return Promise.reject('Repository is read only');
-  }*/
-
   async delete(localPath: string): Promise<void> {
-    // extract current drive name
-    const currentDrive = this._drivesList.filter(
-      x =>
-        x.name ===
-        (localPath.indexOf('/') !== -1
-          ? localPath.substring(0, localPath.indexOf('/'))
-          : localPath)
-    )[0];
+    if (localPath !== '') {
+      // extract current drive name
+      const currentDrive = this._drivesList.filter(
+        x =>
+          x.name ===
+          (localPath.indexOf('/') !== -1
+            ? localPath.substring(0, localPath.indexOf('/'))
+            : localPath)
+      )[0];
 
-    // eliminate drive name from path
-    const relativePath =
-      localPath.indexOf('/') !== -1
-        ? localPath.substring(localPath.indexOf('/') + 1)
-        : '';
+      // eliminate drive name from path
+      const relativePath =
+        localPath.indexOf('/') !== -1
+          ? localPath.substring(localPath.indexOf('/') + 1)
+          : '';
 
-    await deleteObjects(currentDrive.name, {
-      path: relativePath
-    });
+      await deleteObjects(currentDrive.name, {
+        path: relativePath
+      });
+    } else {
+      // create new element at root would mean modifying a drive
+      console.warn('Operation not supported.');
+    }
 
     this._fileChanged.emit({
       type: 'delete',
@@ -444,43 +444,48 @@ export class Drive implements Contents.IDrive {
     newLocalPath: string,
     options: Contents.ICreateOptions = {}
   ): Promise<Contents.IModel> {
-    // extract current drive name
-    const currentDrive = this._drivesList.filter(
-      x =>
-        x.name ===
-        (oldLocalPath.indexOf('/') !== -1
-          ? oldLocalPath.substring(0, oldLocalPath.indexOf('/'))
-          : oldLocalPath)
-    )[0];
+    if (oldLocalPath !== '') {
+      // extract current drive name
+      const currentDrive = this._drivesList.filter(
+        x =>
+          x.name ===
+          (oldLocalPath.indexOf('/') !== -1
+            ? oldLocalPath.substring(0, oldLocalPath.indexOf('/'))
+            : oldLocalPath)
+      )[0];
 
-    // eliminate drive name from path
-    const relativePath =
-      oldLocalPath.indexOf('/') !== -1
-        ? oldLocalPath.substring(oldLocalPath.indexOf('/') + 1)
-        : '';
-    const newRelativePath =
-      newLocalPath.indexOf('/') !== -1
-        ? newLocalPath.substring(newLocalPath.indexOf('/') + 1)
-        : '';
+      // eliminate drive name from path
+      const relativePath =
+        oldLocalPath.indexOf('/') !== -1
+          ? oldLocalPath.substring(oldLocalPath.indexOf('/') + 1)
+          : '';
+      const newRelativePath =
+        newLocalPath.indexOf('/') !== -1
+          ? newLocalPath.substring(newLocalPath.indexOf('/') + 1)
+          : '';
 
-    // extract new file name
-    let newFileName = PathExt.basename(newLocalPath);
+      // extract new file name
+      let newFileName = PathExt.basename(newLocalPath);
 
-    try {
-      // check if object with chosen name already exists
-      await checkObject(currentDrive.name, {
-        path: newLocalPath
-      });
-      newFileName = await this.incrementName(newLocalPath, this._name);
-    } catch (error) {
-      // HEAD request failed for this file name, continue, as name doesn't already exist.
-    } finally {
-      data = await renameObjects(currentDrive.name, {
-        path: relativePath,
-        newPath: newRelativePath,
-        newFileName: newFileName,
-        registeredFileTypes: this._registeredFileTypes
-      });
+      try {
+        // check if object with chosen name already exists
+        await checkObject(currentDrive.name, {
+          path: newLocalPath
+        });
+        newFileName = await this.incrementName(newLocalPath, this._name);
+      } catch (error) {
+        // HEAD request failed for this file name, continue, as name doesn't already exist.
+      } finally {
+        data = await renameObjects(currentDrive.name, {
+          path: relativePath,
+          newPath: newRelativePath,
+          newFileName: newFileName,
+          registeredFileTypes: this._registeredFileTypes
+        });
+      }
+    } else {
+      // create new element at root would mean modifying a drive
+      console.warn('Operation not supported.');
     }
 
     Contents.validateContentsModel(data);
@@ -543,26 +548,31 @@ export class Drive implements Contents.IDrive {
     localPath: string,
     options: Partial<Contents.IModel> = {}
   ): Promise<Contents.IModel> {
-    // extract current drive name
-    const currentDrive = this._drivesList.filter(
-      x =>
-        x.name ===
-        (localPath.indexOf('/') !== -1
-          ? localPath.substring(0, localPath.indexOf('/'))
-          : localPath)
-    )[0];
+    if (localPath !== '') {
+      // extract current drive name
+      const currentDrive = this._drivesList.filter(
+        x =>
+          x.name ===
+          (localPath.indexOf('/') !== -1
+            ? localPath.substring(0, localPath.indexOf('/'))
+            : localPath)
+      )[0];
 
-    // eliminate drive name from path
-    const relativePath =
-      localPath.indexOf('/') !== -1
-        ? localPath.substring(localPath.indexOf('/') + 1)
-        : '';
+      // eliminate drive name from path
+      const relativePath =
+        localPath.indexOf('/') !== -1
+          ? localPath.substring(localPath.indexOf('/') + 1)
+          : '';
 
-    const data = await saveObject(currentDrive.name, {
-      path: relativePath,
-      param: options,
-      registeredFileTypes: this._registeredFileTypes
-    });
+      data = await saveObject(currentDrive.name, {
+        path: relativePath,
+        param: options,
+        registeredFileTypes: this._registeredFileTypes
+      });
+    } else {
+      // create new element at root would mean modifying a drive
+      console.warn('Operation not supported.');
+    }
 
     Contents.validateContentsModel(data);
     this._fileChanged.emit({
@@ -625,32 +635,41 @@ export class Drive implements Contents.IDrive {
     toDir: string,
     options: Contents.ICreateOptions = {}
   ): Promise<Contents.IModel> {
-    // extract current drive name
-    const currentDrive = this._drivesList.filter(
-      x =>
-        x.name ===
-        (path.indexOf('/') !== -1 ? path.substring(0, path.indexOf('/')) : path)
-    )[0];
+    if (path !== '') {
+      // extract current drive name
+      const currentDrive = this._drivesList.filter(
+        x =>
+          x.name ===
+          (path.indexOf('/') !== -1
+            ? path.substring(0, path.indexOf('/'))
+            : path)
+      )[0];
 
-    // eliminate drive name from path
-    const relativePath =
-      path.indexOf('/') !== -1 ? path.substring(path.indexOf('/') + 1) : '';
-    const toRelativePath =
-      toDir.indexOf('/') !== -1 ? toDir.substring(toDir.indexOf('/') + 1) : '';
+      // eliminate drive name from path
+      const relativePath =
+        path.indexOf('/') !== -1 ? path.substring(path.indexOf('/') + 1) : '';
+      const toRelativePath =
+        toDir.indexOf('/') !== -1
+          ? toDir.substring(toDir.indexOf('/') + 1)
+          : '';
 
-    // construct new file or directory name for the copy
-    const newFileName = await this.incrementCopyName(
-      relativePath,
-      toRelativePath,
-      currentDrive.name
-    );
+      // construct new file or directory name for the copy
+      const newFileName = await this.incrementCopyName(
+        relativePath,
+        toRelativePath,
+        currentDrive.name
+      );
 
-    data = await copyObjects(currentDrive.name, {
-      path: relativePath,
-      toPath: toRelativePath,
-      newFileName: newFileName,
-      registeredFileTypes: this._registeredFileTypes
-    });
+      data = await copyObjects(currentDrive.name, {
+        path: relativePath,
+        toPath: toRelativePath,
+        newFileName: newFileName,
+        registeredFileTypes: this._registeredFileTypes
+      });
+    } else {
+      // create new element at root would mean modifying a drive
+      console.warn('Operation not supported.');
+    }
 
     this._fileChanged.emit({
       type: 'new',

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -421,8 +421,6 @@ export class Drive implements Contents.IDrive {
       // eliminate drive name from path
       const relativePath = formatPath(oldLocalPath);
       const newRelativePath = formatPath(newLocalPath);
-      console.log('rel: ', relativePath);
-      console.log('new: ', newRelativePath);
 
       // extract new file name
       let newFileName = PathExt.basename(newRelativePath);
@@ -436,7 +434,6 @@ export class Drive implements Contents.IDrive {
           newRelativePath,
           currentDrive.name
         );
-        console.log(newFileName);
       } catch (error) {
         // HEAD request failed for this file name, continue, as name doesn't already exist.
       } finally {

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -5,7 +5,7 @@ import { PathExt } from '@jupyterlab/coreutils';
 
 import { IDriveInfo, IRegisteredFileTypes } from './token';
 import {
-  saveFile,
+  saveObject,
   getContents,
   mountDrive,
   createObject,
@@ -558,7 +558,7 @@ export class Drive implements Contents.IDrive {
         ? localPath.substring(localPath.indexOf('/') + 1)
         : '';
 
-    const data = await saveFile(currentDrive.name, {
+    const data = await saveObject(currentDrive.name, {
       path: relativePath,
       param: options,
       registeredFileTypes: this._registeredFileTypes

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -1,7 +1,6 @@
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { Signal, ISignal } from '@lumino/signaling';
 import { Contents, ServerConnection } from '@jupyterlab/services';
-import { PathExt } from '@jupyterlab/coreutils';
 
 import { IDriveInfo, IRegisteredFileTypes } from './token';
 import { saveFile, getContents, mountDrive } from './requests';

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -3,7 +3,13 @@ import { Signal, ISignal } from '@lumino/signaling';
 import { Contents, ServerConnection } from '@jupyterlab/services';
 
 import { IDriveInfo, IRegisteredFileTypes } from './token';
-import { saveFile, getContents, mountDrive, createObject } from './requests';
+import {
+  saveFile,
+  getContents,
+  mountDrive,
+  createObject,
+  deleteObjects
+} from './requests';
 
 let data: Contents.IModel = {
   name: '',
@@ -389,16 +395,24 @@ export class Drive implements Contents.IDrive {
   }*/
 
   async delete(localPath: string): Promise<void> {
-    /*const url = this._getUrl(localPath);
-    const settings = this.serverSettings;
-    const init = { method: 'DELETE' };
-    const response = await ServerConnection.makeRequest(url, init, settings);
-    // TODO: update IPEP27 to specify errors more precisely, so
-    // that error types can be detected here with certainty.
-    if (response.status !== 204) {
-      const err = await ServerConnection.ResponseError.create(response);
-      throw err;
-    }*/
+    // extract current drive name
+    const currentDrive = this._drivesList.filter(
+      x =>
+        x.name ===
+        (localPath.indexOf('/') !== -1
+          ? localPath.substring(0, localPath.indexOf('/'))
+          : localPath)
+    )[0];
+
+    // eliminate drive name from path
+    const relativePath =
+      localPath.indexOf('/') !== -1
+        ? localPath.substring(localPath.indexOf('/') + 1)
+        : '';
+
+    await deleteObjects(currentDrive.name, {
+      path: relativePath
+    });
 
     this._fileChanged.emit({
       type: 'delete',

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -460,11 +460,11 @@ export class Drive implements Contents.IDrive {
         ? localPath.substring(localPath.indexOf('/') + 1)
         : '';
 
-    const resp = await saveFile(currentDrive.name, {
+    const data = await saveFile(currentDrive.name, {
       path: relativePath,
-      param: options
+      param: options,
+      registeredFileTypes: this._registeredFileTypes
     });
-    console.log('contents resp: ', resp);
 
     Contents.validateContentsModel(data);
     this._fileChanged.emit({

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -31,6 +31,7 @@ export async function getDrivesList() {
 
 /**
  * Mount a drive by establishing a connection with it.
+ *
  * @param driveName
  * @param options.provider The provider of the drive to be mounted.
  * @param options.region The region of the drive to be mounted.
@@ -51,8 +52,8 @@ export async function mountDrive(
  * Get contents of a directory or retrieve contents of a specific file.
  *
  * @param driveName
- * @param options.path The path of object to be retrived
- * @param options.path The list containing all registered file types.
+ * @param options.path The path of object to be retrived.
+ * @param options.registeredFileTypes The list containing all registered file types.
  *
  * @returns A promise which resolves with the contents model.
  */
@@ -138,6 +139,16 @@ export async function getContents(
   return data;
 }
 
+/**
+ * Save an object.
+ *
+ * @param driveName
+ * @param options.path The path of the object to be saved.
+ * @param options.param The options sent when getting the request from the content manager.
+ * @param options.registeredFileTypes The list containing all registered file types.
+ *
+ * @returns A promise which resolves with the contents model.
+ */
 export async function saveFile(
   driveName: string,
   options: {

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -184,3 +184,48 @@ export async function saveFile(
   };
   return data;
 }
+
+/**
+ * Create a new object.
+ *
+ * @param driveName
+ * @param options.path The path of new object.
+ * @param options.registeredFileTypes The list containing all registered file types.
+ *
+ * @returns A promise which resolves with the contents model.
+ */
+export async function createObject(
+  driveName: string,
+  options: {
+    name: string;
+    path: string;
+    registeredFileTypes: IRegisteredFileTypes;
+  }
+) {
+  const path = options.path
+    ? PathExt.join(options.path, options.name)
+    : options.name;
+  const response = await requestAPI<any>(
+    'drives/' + driveName + '/' + path,
+    'POST'
+  );
+
+  const [fileType, fileMimeType, fileFormat] = getFileType(
+    PathExt.extname(PathExt.basename(options.name)),
+    options.registeredFileTypes
+  );
+
+  data = {
+    name: options.name,
+    path: PathExt.join(driveName, path),
+    last_modified: response.data.last_modified,
+    created: response.data.last_modified,
+    content: response.data.content,
+    format: fileFormat as Contents.FileFormat,
+    mimetype: fileMimeType,
+    size: response.data.size,
+    writable: true,
+    type: fileType
+  };
+  return data;
+}

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -143,18 +143,9 @@ export async function saveFile(
   options: {
     path: string;
     param: Partial<Contents.IModel>;
+    registeredFileTypes: IRegisteredFileTypes;
   }
 ) {
-  // const [fileType, fileMimeType, fileFormat] = getFileType(
-  //   PathExt.extname(PathExt.basename(options.path)),
-  //   options.registeredFileTypes
-  // );
-
-  // const formattedBody = Private.formatBody(options.param, fileFormat, fileType, fileMimeType);
-  // const body: ReadonlyJSONObject = {
-  //   content: formattedBody
-  // };
-
   const response = await requestAPI<any>(
     'drives/' + driveName + '/' + options.path,
     'PUT',
@@ -162,5 +153,23 @@ export async function saveFile(
       content: options.param.content
     }
   );
-  console.log('response: ', response);
+
+  const [fileType, fileMimeType, fileFormat] = getFileType(
+    PathExt.extname(PathExt.basename(options.path)),
+    options.registeredFileTypes
+  );
+
+  data = {
+    name: PathExt.basename(options.path),
+    path: PathExt.join(driveName, options.path),
+    last_modified: response.data.last_modified,
+    created: response.data.last_modified,
+    content: response.data.content,
+    format: fileFormat as Contents.FileFormat,
+    mimetype: fileMimeType,
+    size: response.data.size,
+    writable: true,
+    type: fileType
+  };
+  return data;
 }

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -1,5 +1,6 @@
 import { ReadonlyJSONObject } from '@lumino/coreutils';
 import { requestAPI } from './handler';
+import { Contents } from '@jupyterlab/services';
 
 /**
  * Fetch the list of available drives.
@@ -23,4 +24,31 @@ export async function mountDrive(
     region: options.region
   };
   return await requestAPI<any>('drives', 'POST', body);
+}
+
+export async function saveFile(
+  driveName: string,
+  options: {
+    path: string;
+    param: Partial<Contents.IModel>;
+  }
+) {
+  // const [fileType, fileMimeType, fileFormat] = getFileType(
+  //   PathExt.extname(PathExt.basename(options.path)),
+  //   options.registeredFileTypes
+  // );
+
+  // const formattedBody = Private.formatBody(options.param, fileFormat, fileType, fileMimeType);
+  // const body: ReadonlyJSONObject = {
+  //   content: formattedBody
+  // };
+
+  const response = await requestAPI<any>(
+    'drives/' + driveName + '/' + options.path,
+    'PUT',
+    {
+      content: options.param.content
+    }
+  );
+  console.log('response: ', response);
 }

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -151,7 +151,7 @@ export async function getContents(
  *
  * @returns A promise which resolves with the contents model.
  */
-export async function saveFile(
+export async function saveObject(
   driveName: string,
   options: {
     path: string;
@@ -159,17 +159,20 @@ export async function saveFile(
     registeredFileTypes: IRegisteredFileTypes;
   }
 ) {
+  const [fileType, fileMimeType, fileFormat] = getFileType(
+    PathExt.extname(PathExt.basename(options.path)),
+    options.registeredFileTypes
+  );
+
   const response = await requestAPI<any>(
     'drives/' + driveName + '/' + options.path,
     'PUT',
     {
-      content: options.param.content
+      content: options.param.content,
+      options_format: options.param.format,
+      content_format: fileFormat,
+      content_type: fileType
     }
-  );
-
-  const [fileType, fileMimeType, fileFormat] = getFileType(
-    PathExt.extname(PathExt.basename(options.path)),
-    options.registeredFileTypes
   );
 
   data = {

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -431,12 +431,7 @@ export async function checkObject(
     path: string;
   }
 ) {
-  const response = await requestAPI<any>(
-    'drives/' + driveName + '/' + options.path,
-    'HEAD'
-  );
-
-  return response.result;
+  await requestAPI<any>('drives/' + driveName + '/' + options.path, 'HEAD');
 }
 
 /**
@@ -454,9 +449,10 @@ export const countObjectNameAppearances = async (
   originalName: string
 ): Promise<number> => {
   let counter: number = 0;
+  path = path.substring(0, path.lastIndexOf('/'));
 
   const response = await requestAPI<any>(
-    'drives/' + driveName + '/' + path.substring(0, path.lastIndexOf('/')),
+    'drives/' + driveName + '/' + path,
     'GET'
   );
 

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -88,7 +88,9 @@ export async function getContents(
 
           fileList[fileName] = fileList[fileName] ?? {
             name: fileName,
-            path: driveName + '/' + row.path,
+            path: options.path
+              ? PathExt.join(driveName, options.path, fileName)
+              : PathExt.join(driveName, fileName),
             last_modified: row.last_modified,
             created: '',
             content: !fileName.split('.')[1] ? [] : null,
@@ -102,8 +104,8 @@ export async function getContents(
       });
 
       data = {
-        name: options.path ? PathExt.basename(options.path) : '',
-        path: options.path ? options.path + '/' : '',
+        name: options.path ? PathExt.basename(options.path) : driveName,
+        path: PathExt.join(driveName, options.path ? options.path + '/' : ''),
         last_modified: '',
         created: '',
         content: Object.values(fileList),
@@ -123,7 +125,7 @@ export async function getContents(
 
       data = {
         name: PathExt.basename(options.path),
-        path: driveName + '/' + response.data.path,
+        path: PathExt.join(driveName, response.data.path),
         last_modified: response.data.last_modified,
         created: '',
         content: response.data.content,

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -264,6 +264,63 @@ export async function deleteObjects(
   return Private.deleteSingleObject(driveName, options.path);
 }
 
+/**
+ * Check existance of an object.
+ *
+ * @param driveName
+ * @param options.path The path to the object.
+ *
+ * @returns A promise which resolves or rejects depending on the object existing.
+ */
+export async function checkObject(
+  driveName: string,
+  options: {
+    path: string;
+  }
+) {
+  const response = await requestAPI<any>(
+    'drives/' + driveName + '/' + options.path,
+    'HEAD'
+  );
+
+  return response.result;
+}
+
+/**
+ * Count number of appeareances of object name.
+ *
+ * @param driveName:
+ * @param path: The path to the object.
+ * @param originalName: The original name of the object (before it was incremented).
+ *
+ * @returns A promise which resolves with the number of appeareances of object.
+ */
+export const countObjectNameAppearances = async (
+  driveName: string,
+  path: string,
+  originalName: string
+): Promise<number> => {
+  let counter: number = 0;
+
+  const response = await requestAPI<any>(
+    'drives/' + driveName + '/' + path.substring(0, path.lastIndexOf('/')),
+    'GET'
+  );
+
+  if (response.data && response.data.length !== 0) {
+    response.data.forEach((c: any) => {
+      const fileName = c.row.replace(path ? path + '/' : '', '').split('/')[0];
+      if (
+        fileName.substring(0, originalName.length + 1).includes(originalName)
+      ) {
+        counter += 1;
+      }
+    });
+  }
+
+  return counter;
+};
+
 namespace Private {
   /**
    * Helping function for deleting files inside

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -263,8 +263,12 @@ export async function deleteObjects(
       })
     );
   }
-  // always deleting the object (file or main directory)
-  return Private.deleteSingleObject(driveName, options.path);
+  try {
+    // always deleting the object (file or main directory)
+    return Private.deleteSingleObject(driveName, options.path);
+  } catch (error) {
+    // deleting failed if directory didn't exist and was only part of a path
+  }
 }
 
 /**

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -268,7 +268,10 @@ export async function deleteObjects(
  * Rename an object.
  *
  * @param driveName
- * @param options.path The path of object.
+ * @param options.path The original path of object.
+ * @param options.newPath The new path of object.
+ * @param options.newFileName The name of the item to be renamed.
+ * @param options.registeredFileTypes The list containing all registered file types.
  *
  * @returns A promise which resolves with the contents model.
  */

--- a/src/token.ts
+++ b/src/token.ts
@@ -78,3 +78,26 @@ export function getFileType(
 
   return [fileType, fileMimetype, fileFormat];
 }
+
+/**
+ * Helping function to extract current drive.
+ * @param path
+ * @param drivesList
+ * @returns current drive
+ */
+export function extractCurrentDrive(path: string, drivesList: IDriveInfo[]) {
+  return drivesList.filter(
+    x =>
+      x.name ===
+      (path.indexOf('/') !== -1 ? path.substring(0, path.indexOf('/')) : path)
+  )[0];
+}
+
+/**
+ * Helping function to eliminate drive name from path
+ * @param path
+ * @returns fornatted path without drive name
+ */
+export function formatPath(path: string) {
+  return path.indexOf('/') !== -1 ? path.substring(path.indexOf('/') + 1) : '';
+}


### PR DESCRIPTION
Added backend implementation and connection to frontend contents manager for the following functionalities: 
- create new object
- save existing object with new contents
- rename object
- copy object
- delete object
- check existence of object within drive
- count appearances of object within drive.

For the saving and creation functionalities, a formatting of the content was also needed, depending on its format. 