### PR TITLE
Connect to `boto` client for certain supporting operations 

### DIFF
--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -272,8 +272,8 @@ class JupyterDrivesManager():
             path = path.strip('/')
 
             # TO DO: switch to mode "created", which is not implemented yet
-            await obs.put_async(self._content_managers[drive_name], path, b"", mode = "overwrite")
-            metadata = await obs.head_async(self._content_managers[drive_name], path)
+            await obs.put_async(self._content_managers[drive_name]["store"], path, b"", mode = "overwrite")
+            metadata = await obs.head_async(self._content_managers[drive_name]["store"], path)
 
             data = {
                 "path": path,
@@ -329,8 +329,8 @@ class JupyterDrivesManager():
             else:
                 formatted_content = content
 
-            await obs.put_async(self._content_managers[drive_name], path, formatted_content, mode = "overwrite")
-            metadata = await obs.head_async(self._content_managers[drive_name], path)
+            await obs.put_async(self._content_managers[drive_name]["store"], path, formatted_content, mode = "overwrite")
+            metadata = await obs.head_async(self._content_managers[drive_name]["store"], path)
 
             data = {
                 "path": path,
@@ -362,8 +362,8 @@ class JupyterDrivesManager():
             # eliminate leading and trailing backslashes
             path = path.strip('/')
             
-            await obs.rename_async(self._content_managers[drive_name], path, new_path)
-            metadata = await obs.head_async(self._content_managers[drive_name], new_path)
+            await obs.rename_async(self._content_managers[drive_name]["store"], path, new_path)
+            metadata = await obs.head_async(self._content_managers[drive_name]["store"], new_path)
 
             data = {
                 "path": new_path,
@@ -391,7 +391,7 @@ class JupyterDrivesManager():
         try: 
             # eliminate leading and trailing backslashes
             path = path.strip('/')
-            await obs.delete_async(self._content_managers[drive_name], path)
+            await obs.delete_async(self._content_managers[drive_name]["store"], path)
 
         except Exception as e:
             raise tornado.web.HTTPError(
@@ -411,7 +411,7 @@ class JupyterDrivesManager():
         try: 
             # eliminate leading and trailing backslashes
             path = path.strip('/')
-            await obs.head_async(self._content_managers[drive_name], path)
+            await obs.head_async(self._content_managers[drive_name]["store"], path)
         except Exception:
            raise tornado.web.HTTPError(
             status_code= httpx.codes.NOT_FOUND,
@@ -433,8 +433,8 @@ class JupyterDrivesManager():
             # eliminate leading and trailing backslashes
             path = path.strip('/')
 
-            await obs.copy_async(self._content_managers[drive_name], path, to_path)
-            metadata = await obs.head_async(self._content_managers[drive_name], to_path)
+            await obs.copy_async(self._content_managers[drive_name]["store"], path, to_path)
+            metadata = await obs.head_async(self._content_managers[drive_name]["store"], to_path)
 
             data = {
                 "path": to_path,

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -294,6 +294,30 @@ class JupyterDrivesManager():
     
         return location
     
+    def _check_object(self, drive_name, path):
+        """Helping function to check if we are dealing with an empty file or directory.
+
+        Args:
+            drive_name: name of drive where object exists
+            path: path to object to check
+        """
+        isDir = False
+        try:
+            location = self._content_managers[drive_name]["location"]
+            if location not in self._s3_clients:
+                self._s3_clients[location] = self._s3_session.client('s3', location)
+
+            listing = self._s3_clients[location].list_objects_v2(Bucket = drive_name, Prefix = path + '/')
+            if 'Contents' in listing:
+                isDir = True
+        except Exception as e:
+             raise tornado.web.HTTPError(
+            status_code= httpx.codes.BAD_REQUEST,
+            reason=f"The following error occured when retriving the drive location: {e}",
+            )
+        
+        return isDir
+    
     async def _call_provider(
         self,
         url: str,

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -240,13 +240,16 @@ class JupyterDrivesManager():
                 }
 
             # dealing with the case of an empty directory, making sure it is not an empty file
-            # TO DO: find better way to check
             if emptyDir is True: 
                 ext_list = ['.R', '.bmp', '.csv', '.gif', '.html', '.ipynb', '.jl', '.jpeg', '.jpg', '.json', '.jsonl', '.md', '.ndjson', '.pdf', '.png', '.py', '.svg', '.tif', '.tiff', '.tsv', '.txt', '.webp', '.yaml', '.yml']
                 object_name = os.path.basename(path)
                 # if object doesn't contain . or doesn't end in one of the registered extensions
                 if object_name.find('.') == -1 or ext_list.count(os.path.splitext(object_name)[1]) == 0:
                     data = []
+                
+                # remove upper logic once directories are fixed
+                check = self._check_object(drive_name, path)
+                print(check)
 
             response = {
                 "data": data


### PR DESCRIPTION
When dealing with the `S3` provider, open a `boto` session with the given credentials. The session is then used to get the region of each available drive and also to create an `S3` client for each region. These clients are used when dealing with the `DriveBrowser` directories, in particular to check if we are dealing with an empty directory, as the `obstore` package does not offer this feature in its implementation (no notion of directories, only files).