### PR TITLE
Support for inter-drives operations

### DIFF
--- a/src/contents.ts
+++ b/src/contents.ts
@@ -597,6 +597,7 @@ export class Drive implements Contents.IDrive {
   ): Promise<Contents.IModel> {
     if (path !== '') {
       const currentDrive = extractCurrentDrive(path, this._drivesList);
+      const toDrive = extractCurrentDrive(toDir, this._drivesList);
 
       // eliminate drive name from path
       const relativePath = formatPath(path);
@@ -606,13 +607,14 @@ export class Drive implements Contents.IDrive {
       const newFileName = await this.incrementCopyName(
         relativePath,
         toRelativePath,
-        currentDrive.name
+        toDrive.name
       );
 
       data = await copyObjects(currentDrive.name, {
         path: relativePath,
         toPath: toRelativePath,
         newFileName: newFileName,
+        toDrive: toDrive.name,
         registeredFileTypes: this._registeredFileTypes
       });
     } else {

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -362,6 +362,7 @@ export async function copyObjects(
     path: string;
     toPath: string;
     newFileName: string;
+    toDrive: string;
     registeredFileTypes: IRegisteredFileTypes;
   }
 ) {
@@ -385,6 +386,7 @@ export async function copyObjects(
         const remainingFilePath = c.path.substring(options.path.length);
         Private.copySingleObject(
           driveName,
+          options.toDrive,
           PathExt.join(options.path, remainingFilePath),
           PathExt.join(formattedNewPath, remainingFilePath)
         );
@@ -395,12 +397,13 @@ export async function copyObjects(
   try {
     const copiedObject = await Private.copySingleObject(
       driveName,
+      options.toDrive,
       options.path,
       formattedNewPath
     );
     data = {
       name: options.newFileName,
-      path: PathExt.join(driveName, formattedNewPath),
+      path: PathExt.join(options.toDrive, formattedNewPath),
       last_modified: copiedObject.data.last_modified,
       created: '',
       content: PathExt.extname(options.newFileName) !== '' ? null : [], // TODO: add dir check
@@ -540,6 +543,7 @@ namespace Private {
    */
   export async function copySingleObject(
     driveName: string,
+    toDrive: string,
     objectPath: string,
     newObjectPath: string
   ) {
@@ -547,7 +551,8 @@ namespace Private {
       'drives/' + driveName + '/' + objectPath,
       'PUT',
       {
-        to_path: newObjectPath
+        to_path: newObjectPath,
+        to_drive: toDrive
       }
     );
   }


### PR DESCRIPTION
Add support for the inter-drives operations, in particular for copying and pasting an object from one drive to another.