### PR TITLE
Add configurable limit for number of objects listed in `DriveBrowser`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ c = get_config()
 
 c.DrivesConfig.access_key_id = "<Drives Access Key ID / IAM Access Key ID>"
 c.DrivesConfig.secret_access_key = "<Drives Secret Access Key / IAM Secret>"
-c.DrivesConfig.session_token = "<Drives Session Token / IAM Session Token>"
+c.DrivesConfig.session_token = "<Drives Session Token / IAM Session Token (optional)>"
+c.DrivesConfig.provider = "<Drives provider e.g.: s3, gcs>"
+c.DrivesConfig.max_files_shown = "<Integer repersenting maximum number of files that can be shown in a listing, given any path (optional)>"
 ```
 
 ### Custom credentials file path
@@ -61,6 +63,7 @@ export JP_DRIVES_ACCESS_KEY_ID="<Drives Access Key ID>"
 export JP_DRIVES_SECRET_ACCESS_KEY="<Drives Secret Access Key>"
 export JP_DRIVES_SESSION_TOKEN="<Drives Session Token (optional)>"
 export JP_DRIVES_CUSTOM_CREDENTIALS_PATH="<Path to local file which contains credentials (optional)>"
+export JP_DRIVES_MAX_FILES_SHOWN="<Integer repersenting maximum number of files that can be shown in a listing, given any path (optional)>"
 ```
 
 ## Uninstall

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ c.DrivesConfig.access_key_id = "<Drives Access Key ID / IAM Access Key ID>"
 c.DrivesConfig.secret_access_key = "<Drives Secret Access Key / IAM Secret>"
 c.DrivesConfig.session_token = "<Drives Session Token / IAM Session Token (optional)>"
 c.DrivesConfig.provider = "<Drives provider e.g.: s3, gcs>"
-c.DrivesConfig.max_files_shown = "<Integer repersenting maximum number of files that can be shown in a listing, given any path (optional)>"
+c.DrivesConfig.max_files_listed = "<Integer repersenting maximum number of files that can be shown in a listing, given any path (optional)>"
 ```
 
 ### Custom credentials file path
@@ -63,7 +63,7 @@ export JP_DRIVES_ACCESS_KEY_ID="<Drives Access Key ID>"
 export JP_DRIVES_SECRET_ACCESS_KEY="<Drives Secret Access Key>"
 export JP_DRIVES_SESSION_TOKEN="<Drives Session Token (optional)>"
 export JP_DRIVES_CUSTOM_CREDENTIALS_PATH="<Path to local file which contains credentials (optional)>"
-export JP_DRIVES_MAX_FILES_SHOWN="<Integer repersenting maximum number of files that can be shown in a listing, given any path (optional)>"
+export JP_DRIVES_MAX_FILES_LISTED="<Integer repersenting maximum number of files that can be shown in a listing, given any path (optional)>"
 ```
 
 ## Uninstall

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ c.DrivesConfig.access_key_id = "<Drives Access Key ID / IAM Access Key ID>"
 c.DrivesConfig.secret_access_key = "<Drives Secret Access Key / IAM Secret>"
 c.DrivesConfig.session_token = "<Drives Session Token / IAM Session Token (optional)>"
 c.DrivesConfig.provider = "<Drives provider e.g.: s3, gcs>"
-c.DrivesConfig.max_files_listed = "<Integer repersenting maximum number of files that can be shown in a listing, given any path (optional)>"
 ```
 
 ### Custom credentials file path
@@ -63,7 +62,6 @@ export JP_DRIVES_ACCESS_KEY_ID="<Drives Access Key ID>"
 export JP_DRIVES_SECRET_ACCESS_KEY="<Drives Secret Access Key>"
 export JP_DRIVES_SESSION_TOKEN="<Drives Session Token (optional)>"
 export JP_DRIVES_CUSTOM_CREDENTIALS_PATH="<Path to local file which contains credentials (optional)>"
-export JP_DRIVES_MAX_FILES_LISTED="<Integer repersenting maximum number of files that can be shown in a listing, given any path (optional)>"
 ```
 
 ## Uninstall

--- a/jupyter_drives/base.py
+++ b/jupyter_drives/base.py
@@ -59,6 +59,13 @@ class DrivesConfig(Configurable):
         help="Custom path of file where credentials are located. Extension automatically checks jupyter_notebook_config.py or directly in ~/.aws/credentials for AWS CLI users."
     )
 
+    max_files_shown = Unicode(
+        None,
+        config = True,
+        allow_none = True,
+        help="The maximum number of files that will show inside the drive browser, given any path."
+    )
+
     @default("api_base_url")
     def set_default_api_base_url(self):
         # for AWS S3 drives
@@ -81,6 +88,13 @@ class DrivesConfig(Configurable):
         self._load_credentials()
     
     def _load_credentials(self):
+        # check if max_files_shown is not set in jupyter_notebook_config.py
+        if self.max_files_shown is None:
+            if "JP_DRIVES_MAX_FILES_SHOWN" in os.environ:
+                self.max_files_shown = os.environ["JP_DRIVES_MAX_FILES_SHOWN"]
+            else:
+                self.max_files_shown = 1000
+        
         # check if credentials were already set in jupyter_notebook_config.py
         if self.access_key_id is not None and self.secret_access_key is not None:
             return
@@ -89,7 +103,7 @@ class DrivesConfig(Configurable):
         if self.custom_credentials_path is None and "JP_DRIVES_CUSTOM_CREDENTIALS_PATH" in os.environ:
             self.custom_credentials_path = os.environ["JP_DRIVES_CUSTOM_CREDENTIALS_PATH"]
         if self.custom_credentials_path is not None:
-            self.provider, self.access_key_id, self.secret_access_key, self.session_token = self._extract_credentials_from_file(self.custom_credentials_path)
+            self.provider, self.access_key_id, self.secret_access_key, self.session_token, self.max_files_shown = self._extract_credentials_from_file(self.custom_credentials_path)
             return
         
         # if not, try to load credentials from AWS CLI
@@ -112,9 +126,10 @@ class DrivesConfig(Configurable):
         try:
             with open(file_path, 'r') as file:
                 provider, access_key_id, secret_access_key, session_token = None, None, None, None
+                max_files_shown = 1000
                 lines = file.readlines()
                 for line in lines:
-                    if line.startswith("provider ="):
+                    if line.startswith("drives_provider ="):
                         provider = line.split("=")[1].strip()
                     elif line.startswith("drives_access_key_id ="):
                         access_key_id = line.split("=")[1].strip()
@@ -122,7 +137,9 @@ class DrivesConfig(Configurable):
                         secret_access_key = line.split("=")[1].strip()
                     elif line.startswith("drives_session_token ="):
                         session_token = line.split("=")[1].strip()
-                return provider, access_key_id, secret_access_key, session_token
+                    elif line.startswith("drives_max_files_shwon ="):
+                        max_files_shown = line.split("=")[1].strip()
+                return provider, access_key_id, secret_access_key, session_token, max_files_shown
         except Exception as e:
             print(f"Failed loading credentials from {file_path}: {e}")
         return

--- a/jupyter_drives/base.py
+++ b/jupyter_drives/base.py
@@ -59,7 +59,7 @@ class DrivesConfig(Configurable):
         help="Custom path of file where credentials are located. Extension automatically checks jupyter_notebook_config.py or directly in ~/.aws/credentials for AWS CLI users."
     )
 
-    max_files_shown = Int(
+    max_files_listed = Int(
         None,
         config = True,
         allow_none = True,
@@ -89,11 +89,11 @@ class DrivesConfig(Configurable):
     
     def _load_credentials(self):
         # check if max_files_shown is not set in jupyter_notebook_config.py
-        if self.max_files_shown is None:
-            if "JP_DRIVES_MAX_FILES_SHOWN" in os.environ:
-                self.max_files_shown = os.environ["JP_DRIVES_MAX_FILES_SHOWN"]
+        if self.max_files_listed is None:
+            if "JP_DRIVES_MAX_FILES_LISTED" in os.environ:
+                self.max_files_listed = os.environ["JP_DRIVES_MAX_FILES_LISTED"]
             else:
-                self.max_files_shown = 1000
+                self.max_files_listed = 1000
         
         # check if credentials were already set in jupyter_notebook_config.py
         if self.access_key_id is not None and self.secret_access_key is not None:
@@ -103,7 +103,7 @@ class DrivesConfig(Configurable):
         if self.custom_credentials_path is None and "JP_DRIVES_CUSTOM_CREDENTIALS_PATH" in os.environ:
             self.custom_credentials_path = os.environ["JP_DRIVES_CUSTOM_CREDENTIALS_PATH"]
         if self.custom_credentials_path is not None:
-            self.provider, self.access_key_id, self.secret_access_key, self.session_token, self.max_files_shown = self._extract_credentials_from_file(self.custom_credentials_path)
+            self.provider, self.access_key_id, self.secret_access_key, self.session_token, self.max_files_listed = self._extract_credentials_from_file(self.custom_credentials_path)
             return
         
         # if not, try to load credentials from AWS CLI
@@ -126,7 +126,7 @@ class DrivesConfig(Configurable):
         try:
             with open(file_path, 'r') as file:
                 provider, access_key_id, secret_access_key, session_token = None, None, None, None
-                max_files_shown = 1000
+                max_files_listed = 1000
                 lines = file.readlines()
                 for line in lines:
                     if line.startswith("drives_provider ="):
@@ -138,8 +138,8 @@ class DrivesConfig(Configurable):
                     elif line.startswith("drives_session_token ="):
                         session_token = line.split("=")[1].strip()
                     elif line.startswith("drives_max_files_shwon ="):
-                        max_files_shown = line.split("=")[1].strip()
-                return provider, access_key_id, secret_access_key, session_token, max_files_shown
+                        max_files_listed = line.split("=")[1].strip()
+                return provider, access_key_id, secret_access_key, session_token, max_files_listed
         except Exception as e:
             print(f"Failed loading credentials from {file_path}: {e}")
         return

--- a/jupyter_drives/base.py
+++ b/jupyter_drives/base.py
@@ -1,7 +1,7 @@
 import os
 from sys import platform
 import entrypoints
-from traitlets import Enum, Unicode, default
+from traitlets import Enum, Unicode, default, Int
 from traitlets.config import Configurable
 
 # Supported third-party services
@@ -59,7 +59,7 @@ class DrivesConfig(Configurable):
         help="Custom path of file where credentials are located. Extension automatically checks jupyter_notebook_config.py or directly in ~/.aws/credentials for AWS CLI users."
     )
 
-    max_files_shown = Unicode(
+    max_files_shown = Int(
         None,
         config = True,
         allow_none = True,

--- a/jupyter_drives/base.py
+++ b/jupyter_drives/base.py
@@ -59,13 +59,6 @@ class DrivesConfig(Configurable):
         help="Custom path of file where credentials are located. Extension automatically checks jupyter_notebook_config.py or directly in ~/.aws/credentials for AWS CLI users."
     )
 
-    max_files_listed = Int(
-        None,
-        config = True,
-        allow_none = True,
-        help="The maximum number of files that will show inside the drive browser, given any path."
-    )
-
     @default("api_base_url")
     def set_default_api_base_url(self):
         # for AWS S3 drives
@@ -87,14 +80,7 @@ class DrivesConfig(Configurable):
         super().__init__(**kwargs)
         self._load_credentials()
     
-    def _load_credentials(self):
-        # check if max_files_shown is not set in jupyter_notebook_config.py
-        if self.max_files_listed is None:
-            if "JP_DRIVES_MAX_FILES_LISTED" in os.environ:
-                self.max_files_listed = os.environ["JP_DRIVES_MAX_FILES_LISTED"]
-            else:
-                self.max_files_listed = 1000
-        
+    def _load_credentials(self):        
         # check if credentials were already set in jupyter_notebook_config.py
         if self.access_key_id is not None and self.secret_access_key is not None:
             return
@@ -103,7 +89,7 @@ class DrivesConfig(Configurable):
         if self.custom_credentials_path is None and "JP_DRIVES_CUSTOM_CREDENTIALS_PATH" in os.environ:
             self.custom_credentials_path = os.environ["JP_DRIVES_CUSTOM_CREDENTIALS_PATH"]
         if self.custom_credentials_path is not None:
-            self.provider, self.access_key_id, self.secret_access_key, self.session_token, self.max_files_listed = self._extract_credentials_from_file(self.custom_credentials_path)
+            self.provider, self.access_key_id, self.secret_access_key, self.session_token = self._extract_credentials_from_file(self.custom_credentials_path)
             return
         
         # if not, try to load credentials from AWS CLI
@@ -126,7 +112,6 @@ class DrivesConfig(Configurable):
         try:
             with open(file_path, 'r') as file:
                 provider, access_key_id, secret_access_key, session_token = None, None, None, None
-                max_files_listed = 1000
                 lines = file.readlines()
                 for line in lines:
                     if line.startswith("drives_provider ="):
@@ -137,9 +122,7 @@ class DrivesConfig(Configurable):
                         secret_access_key = line.split("=")[1].strip()
                     elif line.startswith("drives_session_token ="):
                         session_token = line.split("=")[1].strip()
-                    elif line.startswith("drives_max_files_shwon ="):
-                        max_files_listed = line.split("=")[1].strip()
-                return provider, access_key_id, secret_access_key, session_token, max_files_listed
+                return provider, access_key_id, secret_access_key, session_token
         except Exception as e:
             print(f"Failed loading credentials from {file_path}: {e}")
         return

--- a/jupyter_drives/base.py
+++ b/jupyter_drives/base.py
@@ -1,7 +1,7 @@
 import os
 from sys import platform
 import entrypoints
-from traitlets import Enum, Unicode, default, Int
+from traitlets import Enum, Unicode, default
 from traitlets.config import Configurable
 
 # Supported third-party services

--- a/jupyter_drives/handlers.py
+++ b/jupyter_drives/handlers.py
@@ -42,6 +42,19 @@ class JupyterDrivesAPIHandler(APIHandler):
                 reply["error"] = "".join(traceback.format_exception(*exc_info))
         self.finish(json.dumps(reply))
 
+class ConfigJupyterDrivesHandler(JupyterDrivesAPIHandler):
+    """
+    Set certain configuration variables in drives manager.
+    """
+    def initialize(self, logger: logging.Logger, manager: JupyterDrivesManager):
+        return super().initialize(logger, manager)
+    
+    @tornado.web.authenticated
+    async def post(self):
+        body = self.get_json_body()
+        result = self._manager.set_listing_limit(**body)
+        self.finish(result)
+
 class ListJupyterDrivesHandler(JupyterDrivesAPIHandler):
     """
     List available drives. Mounts drives.
@@ -106,7 +119,8 @@ class ContentsJupyterDrivesHandler(JupyterDrivesAPIHandler):
         self.finish(result)
 
 handlers = [
-    ("drives", ListJupyterDrivesHandler)
+    ("drives", ListJupyterDrivesHandler),
+    ("drives/config", ConfigJupyterDrivesHandler),
 ]
 
 handlers_with_path = [

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -40,6 +40,7 @@ class JupyterDrivesManager():
         self._config = DrivesConfig(config=config)
         self._client = httpx.AsyncClient()
         self._content_managers = {}
+        self._max_files_listed = 1000
 
          # initiate boto3 session if we are dealing with S3 drives
         if self._config.provider == 's3':
@@ -73,6 +74,22 @@ class JupyterDrivesManager():
             None: the provider does not support pagination
         """
         return ("per_page", 100)
+    
+    def set_listing_limit(self, new_limit):
+        """Set new limit for listing.
+
+        Args:
+            new_limit: new maximum to be set
+        """
+        try:
+            self._max_files_listed = new_limit
+        except Exception as e:
+            raise tornado.web.HTTPError(
+            status_code= httpx.codes.BAD_REQUEST,
+            reason= f"The following error occured when setting the new listing limit: {e}"
+            )
+
+        return
     
     async def list_drives(self): 
         """Get list of available drives.
@@ -129,9 +146,6 @@ class JupyterDrivesManager():
 
         Args:
             drive_name: name of drive to mount
-
-        Returns:
-            The content manager for the drive.
         """
         try: 
             # check if content manager doesn't already exist
@@ -210,9 +224,9 @@ class JupyterDrivesManager():
             emptyDir = True # assume we are dealing with an empty directory
 
             chunk_size = 100
-            if self._config.max_files_listed < chunk_size:
-                chunk_size = self._config.max_files_listed
-            no_batches = int(self._config.max_files_listed/chunk_size)
+            if self._max_files_listed < chunk_size:
+                chunk_size = self._max_files_listed
+            no_batches = int(self._max_files_listed/chunk_size)
 
             # using Arrow lists as they are recommended for large results
             # stream will be an async iterable of RecordBatch
@@ -222,7 +236,7 @@ class JupyterDrivesManager():
                 current_batch += 1
                 # reached last batch that can be shown (partially)
                 if current_batch == no_batches + 1:
-                    remaining_files = self._config.max_files_listed - no_batches*chunk_size
+                    remaining_files = self._max_files_listed - no_batches*chunk_size
                     
                 # if content exists we are dealing with a directory
                 if isDir is False and batch: 

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -194,9 +194,9 @@ class JupyterDrivesManager():
             emptyDir = True # assume we are dealing with an empty directory
 
             chunk_size = 100
-            if self._config.max_files_shown < chunk_size:
-                chunk_size = self._config.max_files_shown
-            no_batches = int(self._config.max_files_shown/chunk_size)
+            if self._config.max_files_listed < chunk_size:
+                chunk_size = self._config.max_files_listed
+            no_batches = int(self._config.max_files_listed/chunk_size)
 
             # using Arrow lists as they are recommended for large results
             # stream will be an async iterable of RecordBatch
@@ -206,7 +206,7 @@ class JupyterDrivesManager():
                 current_batch += 1
                 # reached last batch that can be shown (partially)
                 if current_batch == no_batches + 1:
-                    remaining_files = self._config.max_files_shown - no_batches*chunk_size
+                    remaining_files = self._config.max_files_listed - no_batches*chunk_size
                     
                 # if content exists we are dealing with a directory
                 if isDir is False and batch: 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "obstore>=0.2.0,<0.3",
+    "obstore>=0.3.0b,<0.4",
+    "arro3-core>=0.2.1,<0.3",
     "pyarrow>=18.0.0,<19.0.0",
     "jupyter_server>=2.14.2,<3",
     "s3contents>=0.11.1,<0.12.0",

--- a/schema/drives-file-browser.json
+++ b/schema/drives-file-browser.json
@@ -1,5 +1,5 @@
 {
-  "title": "Jupyter Drives Settings",
+  "title": "Drives Browser Settings",
   "description": "jupyter-drives settings.",
   "jupyter.lab.toolbars": {
     "DriveBrowser": [

--- a/schema/drives-file-browser.json
+++ b/schema/drives-file-browser.json
@@ -40,6 +40,12 @@
   "type": "object",
   "jupyter.lab.transform": true,
   "properties": {
+    "maxFilesListed": {
+      "type": "integer",
+      "title": "Maximum number of objects listed",
+      "description": "Configure maximum number of objects that will be shown in a listing, given any path.",
+      "default": 1000
+    },
     "toolbar": {
       "title": "Drive browser toolbar items",
       "description": "Note: To disable a toolbar item,\ncopy it to User Preferences and add the\n\"disabled\" key.",

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -45,7 +45,6 @@ export class Drive implements Contents.IDrive {
     this._serverSettings = ServerConnection.makeSettings();
     this._name = options.name ?? '';
     this._drivesList = options.drivesList ?? [];
-    //this._apiEndpoint = options.apiEndpoint ?? SERVICE_DRIVE_URL;
   }
 
   /**
@@ -719,16 +718,6 @@ export class Drive implements Contents.IDrive {
     }
   }
 
-  /**
-   * Get a REST url for a file given a path.
-   */
-  /*private _getUrl(...args: string[]): string {
-    const parts = args.map(path => URLExt.encodeParts(path));
-    const baseUrl = this.serverSettings.baseUrl;
-    return URLExt.join(baseUrl, this._apiEndpoint, ...parts);
-  }*/
-
-  // private _apiEndpoint: string;
   private _drivesList: IDriveInfo[] = [];
   private _serverSettings: ServerConnection.ISettings;
   private _name: string = '';
@@ -771,17 +760,3 @@ export namespace Drive {
     apiEndpoint?: string;
   }
 }
-
-/*namespace Private {
-  /**
-   * Normalize a file extension to be of the type `'.foo'`.
-   *
-   * Adds a leading dot if not present and converts to lower case.
-   */
-/*export function normalizeExtension(extension: string): string {
-    if (extension.length > 0 && extension.indexOf('.') !== 0) {
-      extension = `.${extension}`;
-    }
-    return extension;
-  }
-}*/

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ import { CommandRegistry } from '@lumino/commands';
 import { DriveListModel, DriveListView, IDrive } from './drivelistmanager';
 import { DriveIcon, driveBrowserIcon } from './icons';
 import { Drive } from './contents';
-import { getDrivesList } from './requests';
+import { getDrivesList, setListingLimit } from './requests';
 import { IDriveInfo, IDrivesList } from './token';
 
 /**
@@ -288,6 +288,34 @@ const driveFileBrowser: JupyterFrontEndPlugin<void> = {
         translator
       )
     );
+
+    /**
+     * Load the settings for this extension
+     *
+     * @param setting Extension settings
+     */
+    function loadSetting(setting: ISettingRegistry.ISettings): void {
+      // Read the settings and convert to the correct type
+      const maxFilesListed = setting.get('maxFilesListed').composite as number;
+      // Set new limit.
+      setListingLimit(maxFilesListed);
+    }
+
+    // Wait for the application to be restored and
+    // for the settings for this plugin to be loaded
+    Promise.all([app.restored, settingsRegistry.load(driveFileBrowser.id)])
+      .then(([, setting]) => {
+        // Read the settings
+        loadSetting(setting);
+
+        // Listen for your plugin setting changes using Signal
+        setting.changed.connect(loadSetting);
+      })
+      .catch(reason => {
+        console.error(
+          `Something went wrong when reading the settings.\n${reason}`
+        );
+      });
   }
 };
 

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -22,6 +22,17 @@ let data: Contents.IModel = {
 };
 
 /**
+ * Set new limit for number of objects to be listed inside the DriveBrowser, given any path.
+ *
+ * @returns
+ */
+export async function setListingLimit(newLimit: number) {
+  await requestAPI<any>('drives/config', 'POST', {
+    new_limit: newLimit
+  });
+}
+
+/**
  * Fetch the list of available drives.
  * @returns The list of available drives.
  */


### PR DESCRIPTION
Add a configurable variable representing the limit of the maximum number of objects that can be shown at once in a listing, given any path. The variable can be changed in the `Drives Browser` settings. The `max_files_listed` defaults to 1000 and the listing is being done in `chunks` of 100.

[Dynamically change listing limit](https://github.com/user-attachments/assets/aed369af-bbbf-4aaf-9d14-918bb263481a)

This PR also complements the logic for using the `session_token` in credentials
