### PR TITLE
Get drive location when mounting

### DIFF
--- a/jupyter_drives/handlers.py
+++ b/jupyter_drives/handlers.py
@@ -66,7 +66,7 @@ class ListJupyterDrivesHandler(JupyterDrivesAPIHandler):
     @tornado.web.authenticated
     async def get(self):
         result = await self._manager.list_drives()
-        self.finish(result)
+        self.finish(json.dumps(result["data"]))
     
     @tornado.web.authenticated
     async def post(self):

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -118,14 +118,11 @@ class JupyterDrivesManager():
                 results += drive.list_containers()
             
             for result in results:
-                # in case of S3 drives get region of each drive
-                if self._config.provider == 's3':
-                    location = self._get_drive_location(result.name)
                 data.append(
                     {
                         "name": result.name,
-                        "region": location,
-                        "creation_date": result.extra["creation_date"],
+                        "region": self._config.region_name,
+                        "creationDate": result.extra["creation_date"],
                         "mounted": False if result.name not in self._content_managers else True,
                         "provider": self._config.provider
                     }
@@ -141,7 +138,7 @@ class JupyterDrivesManager():
         }
         return response
     
-    async def mount_drive(self, drive_name, provider, region):
+    async def mount_drive(self, drive_name, provider):
         """Mount a drive.
 
         Args:
@@ -151,6 +148,8 @@ class JupyterDrivesManager():
             # check if content manager doesn't already exist
             if drive_name not in self._content_managers or self._content_managers[drive_name] is None:
                 if provider == 's3':
+                    # get region of drive
+                    region = self._get_drive_location(drive_name)
                     if self._config.session_token is None:
                         configuration = {
                             "aws_access_key_id": self._config.access_key_id,

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -229,8 +229,7 @@ export class Drive implements Contents.IDrive {
       if (currentDrive.mounted === false) {
         try {
           await mountDrive(localPath, {
-            provider: currentDrive.provider,
-            region: currentDrive.region
+            provider: currentDrive.provider
           });
           this._drivesList.filter(x => x.name === localPath)[0].mounted = true;
         } catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,18 +160,9 @@ const drivesListProvider: JupyterFrontEndPlugin<IDriveInfo[]> = {
   description: 'The drives list provider.',
   provides: IDrivesList,
   activate: async (_: JupyterFrontEnd): Promise<IDriveInfo[]> => {
-    const drives: IDriveInfo[] = [];
+    let drives: IDriveInfo[] = [];
     try {
-      const response = await getDrivesList();
-      for (const drive of response.data) {
-        drives.push({
-          name: drive.name,
-          region: drive.region,
-          provider: drive.provider,
-          creationDate: drive.creation_date,
-          mounted: drive.mounted
-        });
-      }
+      drives = await getDrivesList();
     } catch (error) {
       console.log('Failed loading available drives list, with error: ', error);
     }

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -3,7 +3,12 @@ import { Contents } from '@jupyterlab/services';
 import { PathExt } from '@jupyterlab/coreutils';
 
 import { requestAPI } from './handler';
-import { getFileType, IRegisteredFileTypes, IContentsList } from './token';
+import {
+  getFileType,
+  IRegisteredFileTypes,
+  IContentsList,
+  IDriveInfo
+} from './token';
 
 /**
  * The data contents model.
@@ -37,7 +42,7 @@ export async function setListingLimit(newLimit: number) {
  * @returns The list of available drives.
  */
 export async function getDrivesList() {
-  return await requestAPI<any>('drives', 'GET');
+  return await requestAPI<IDriveInfo[]>('drives', 'GET');
 }
 
 /**
@@ -45,16 +50,14 @@ export async function getDrivesList() {
  *
  * @param driveName
  * @param options.provider The provider of the drive to be mounted.
- * @param options.region The region of the drive to be mounted.
  */
 export async function mountDrive(
   driveName: string,
-  options: { provider: string; region: string }
+  options: { provider: string } //region: string }
 ) {
   const body: ReadonlyJSONObject = {
     drive_name: driveName,
-    provider: options.provider,
-    region: options.region
+    provider: options.provider
   };
   return await requestAPI<any>('drives', 'POST', body);
 }


### PR DESCRIPTION
Update logic when listing drives, such that it uses the region from the configuration, and later extracts the individual drive region when mounting the drive. The region extraction was causing a delay when loading `JupyterLab` and refreshing the page.