### PR TITLE
Provide s3 driver with session token

### DIFF
--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -107,7 +107,7 @@ class JupyterDrivesManager():
         if self._config.access_key_id and self._config.secret_access_key:
             if self._config.provider == "s3":
                 S3Drive = get_driver(Provider.S3)
-                drives = [S3Drive(self._config.access_key_id, self._config.secret_access_key)]
+                drives = [S3Drive(self._config.access_key_id, self._config.secret_access_key, True, None, None, None, self._config.session_token)]
 
             elif self._config.provider == 'gcs':
                 GCSDrive = get_driver(Provider.GOOGLE_STORAGE)


### PR DESCRIPTION
For S3 Driver to work it needs all three, access key, secret key and session token

libcloud S3StorageDriver constructor accepts following: `def __init__(self,key,secret=None,secure=True,host=None,port=None,region=None,token=None,**kwargs)`

See more: https://github.com/apache/libcloud/blob/trunk/libcloud/storage/drivers/s3.py#L1231