### PR TITLE
Remove drives list provider plugin

### DIFF
--- a/src/contents.ts
+++ b/src/contents.ts
@@ -19,7 +19,8 @@ import {
   countObjectNameAppearances,
   renameObjects,
   copyObjects,
-  presignedLink
+  presignedLink,
+  getDrivesList
 } from './requests';
 
 let data: Contents.IModel = {
@@ -245,6 +246,8 @@ export class Drive implements Contents.IDrive {
       // retriving list of contents from root
       // in our case: list available drives
       const drivesList: Contents.IModel[] = [];
+      // fetch list of available drives
+      this._drivesList = await getDrivesList();
       for (const drive of this._drivesList) {
         drivesList.push({
           name: drive.name,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,12 @@
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
 import {
   driveFileBrowser,
-  drivesListProvider,
   openDriveDialogPlugin,
   launcherPlugin
 } from './plugins';
 
 const plugins: JupyterFrontEndPlugin<any>[] = [
   driveFileBrowser,
-  drivesListProvider,
   openDriveDialogPlugin,
   launcherPlugin
 ];

--- a/src/plugins/driveBrowserPlugin.ts
+++ b/src/plugins/driveBrowserPlugin.ts
@@ -245,7 +245,7 @@ namespace Private {
   /**
    * Create the node for a creating a new drive handler.
    */
-  const createNewDriveNode = (newDriveName: string): HTMLElement => {
+  const createNewDriveNode = (): HTMLElement => {
     const body = document.createElement('div');
 
     const drive = document.createElement('label');
@@ -274,7 +274,7 @@ namespace Private {
      * Construct a new "create-drive" dialog.
      */
     constructor(newDriveName: string) {
-      super({ node: createNewDriveNode(newDriveName) });
+      super({ node: createNewDriveNode() });
       this.onAfterAttach();
     }
 

--- a/src/plugins/driveBrowserPlugin.ts
+++ b/src/plugins/driveBrowserPlugin.ts
@@ -22,8 +22,8 @@ import { CommandRegistry } from '@lumino/commands';
 
 import { driveBrowserIcon } from '../icons';
 import { Drive } from '../contents';
-import { getDrivesList, setListingLimit } from '../requests';
-import { IDriveInfo, IDrivesList, CommandIDs } from '../token';
+import { setListingLimit } from '../requests';
+import { CommandIDs } from '../token';
 
 /**
  * The file browser factory ID.
@@ -36,24 +36,6 @@ const FILE_BROWSER_FACTORY = 'DriveBrowser';
 const FILTERBOX_CLASS = 'jp-drive-browser-search-box';
 
 /**
- * The drives list provider.
- */
-export const drivesListProvider: JupyterFrontEndPlugin<IDriveInfo[]> = {
-  id: 'jupyter-drives:drives-list',
-  description: 'The drives list provider.',
-  provides: IDrivesList,
-  activate: async (_: JupyterFrontEnd): Promise<IDriveInfo[]> => {
-    let drives: IDriveInfo[] = [];
-    try {
-      drives = await getDrivesList();
-    } catch (error) {
-      console.log('Failed loading available drives list, with error: ', error);
-    }
-    return drives;
-  }
-};
-
-/**
  * The drive file browser factory provider.
  */
 export const driveFileBrowser: JupyterFrontEndPlugin<void> = {
@@ -64,8 +46,7 @@ export const driveFileBrowser: JupyterFrontEndPlugin<void> = {
     IFileBrowserFactory,
     IToolbarWidgetRegistry,
     ISettingRegistry,
-    ITranslator,
-    IDrivesList
+    ITranslator
   ],
   optional: [
     IRouter,
@@ -79,7 +60,6 @@ export const driveFileBrowser: JupyterFrontEndPlugin<void> = {
     toolbarRegistry: IToolbarWidgetRegistry,
     settingsRegistry: ISettingRegistry,
     translator: ITranslator,
-    drivesList: IDriveInfo[],
     router: IRouter | null,
     tree: JupyterFrontEnd.ITreeResolver | null,
     labShell: ILabShell | null,
@@ -92,8 +72,7 @@ export const driveFileBrowser: JupyterFrontEndPlugin<void> = {
 
     // create drive for drive file browser
     const drive = new Drive({
-      name: 's3',
-      drivesList: drivesList
+      name: 's3'
     });
 
     app.serviceManager.contents.addDrive(drive);

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,4 +1,3 @@
-import { Token } from '@lumino/coreutils';
 import { Contents } from '@jupyterlab/services';
 
 /**
@@ -11,13 +10,6 @@ export namespace CommandIDs {
   export const createNewDrive = 'drives:create-new-drive';
   export const launcher = 'launcher:create';
 }
-
-/**
- * A token for the plugin that provides the list of drives.
- */
-export const IDrivesList = new Token<IDriveInfo[]>(
-  'jupyter-drives:drives-list-provider'
-);
 
 /**
  * An interface that stores the drive information.


### PR DESCRIPTION
Remove the drives list provider plugin in order to enable the drive handling operations (create or delete a drive) and get a dynamic list of available drives (refresh list). The provider plugin is no longer needed, as we are dealing with dynamic operations. 