### PR TITLE
Add drive handling operations

### DIFF
--- a/jupyter_drives/handlers.py
+++ b/jupyter_drives/handlers.py
@@ -89,7 +89,10 @@ class ContentsJupyterDrivesHandler(JupyterDrivesAPIHandler):
     @tornado.web.authenticated
     async def post(self, drive: str = "", path: str = ""):
         body = self.get_json_body()
-        result = await self._manager.new_file(drive, path, **body)
+        if 'location' in body:
+            result = await self._manager.new_drive(**body)
+        else:
+            result = await self._manager.new_file(drive, path, **body)
         self.finish(result)
 
     @tornado.web.authenticated

--- a/jupyter_drives/handlers.py
+++ b/jupyter_drives/handlers.py
@@ -90,7 +90,7 @@ class ContentsJupyterDrivesHandler(JupyterDrivesAPIHandler):
     async def post(self, drive: str = "", path: str = ""):
         body = self.get_json_body()
         if 'location' in body:
-            result = await self._manager.new_drive(**body)
+            result = await self._manager.new_drive(drive, **body)
         else:
             result = await self._manager.new_file(drive, path, **body)
         self.finish(result)

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -445,17 +445,22 @@ class JupyterDrivesManager():
         try: 
             # eliminate leading and trailing backslashes
             path = path.strip('/')
-            is_dir = await self._file_system._isdir(drive_name + '/' + path)
-            if is_dir == True:
-                await self._fix_dir(drive_name, path)
-            await self._file_system._rm(drive_name + '/' + path, recursive = True)
+            object_name = drive_name # in case we are only deleting the drive itself
+            if path != '':
+                # deleting objects within a drive
+                is_dir = await self._file_system._isdir(drive_name + '/' + path)
+                if is_dir == True:
+                    await self._fix_dir(drive_name, path)
+                object_name = drive_name + '/' + path
+            await self._file_system._rm(object_name, recursive = True)
 
             # checking for remaining directories and deleting them
-            stream = obs.list(self._content_managers[drive_name]["store"], path, chunk_size=100, return_arrow=True)
-            async for batch in stream:
-                contents_list = pyarrow.record_batch(batch).to_pylist()
-                for object in contents_list:
-                    await self._fix_dir(drive_name, object["path"], delete_only = True)               
+            if object_name != drive_name:
+                stream = obs.list(self._content_managers[drive_name]["store"], path, chunk_size=100, return_arrow=True)
+                async for batch in stream:
+                    contents_list = pyarrow.record_batch(batch).to_pylist()
+                    for object in contents_list:
+                        await self._fix_dir(drive_name, object["path"], delete_only = True)               
 
         except Exception as e:
             raise tornado.web.HTTPError(

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -563,6 +563,23 @@ class JupyterDrivesManager():
 
         return 
     
+    async def new_drive(self, new_drive_name, location='us-east-1'):
+        """Create a new drive in the given location.
+        
+        Args:
+            new_drive_name: name of new drive to create
+            location: (optional) region of bucket
+        """
+        try:
+            await self._file_system._mkdir(new_drive_name, region_name = location)      
+        except Exception as e:
+            raise tornado.web.HTTPError(
+            status_code= httpx.codes.BAD_REQUEST,
+            reason=f"The following error occured when creating the new drive: {e}",
+            )
+        
+        return
+    
     async def _get_drive_location(self, drive_name):
         """Helping function for getting drive region.
 

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -390,16 +390,11 @@ export class Drive implements Contents.IDrive {
    * @returns A promise which resolves when the file is deleted.
    */
   async delete(localPath: string): Promise<void> {
-    if (localPath !== '') {
-      const currentDrive = extractCurrentDrive(localPath, this._drivesList);
+    const currentDrive = extractCurrentDrive(localPath, this._drivesList);
 
-      await deleteObjects(currentDrive.name, {
-        path: formatPath(localPath)
-      });
-    } else {
-      // create new element at root would mean modifying a drive
-      console.warn('Operation not supported.');
-    }
+    await deleteObjects(currentDrive.name, {
+      path: formatPath(localPath)
+    });
 
     this._fileChanged.emit({
       type: 'delete',

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -19,7 +19,8 @@ import {
   countObjectNameAppearances,
   renameObjects,
   copyObjects,
-  presignedLink
+  presignedLink,
+  createDrive
 } from './requests';
 
 let data: Contents.IModel = {
@@ -622,6 +623,31 @@ export class Drive implements Contents.IDrive {
       newValue: data
     });
     Contents.validateContentsModel(data);
+    return data;
+  }
+
+  /**
+   * Create a new drive.
+   *
+   * @param options: The options used to create the drive.
+   *
+   * @returns A promise which resolves with the contents model.
+   */
+  async newDrive(
+    newDriveName: string,
+    region: string
+  ): Promise<Contents.IModel> {
+    data = await createDrive(newDriveName, {
+      location: region
+    });
+
+    Contents.validateContentsModel(data);
+    this._fileChanged.emit({
+      type: 'new',
+      oldValue: null,
+      newValue: data
+    });
+
     return data;
   }
 

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -20,7 +20,8 @@ import {
   renameObjects,
   copyObjects,
   presignedLink,
-  createDrive
+  createDrive,
+  getDrivesList
 } from './requests';
 
 let data: Contents.IModel = {
@@ -246,6 +247,8 @@ export class Drive implements Contents.IDrive {
       // retriving list of contents from root
       // in our case: list available drives
       const drivesList: Contents.IModel[] = [];
+      // fetch list of available drives
+      this._drivesList = await getDrivesList();
       for (const drive of this._drivesList) {
         drivesList.push({
           name: drive.name,

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -246,22 +246,29 @@ export class Drive implements Contents.IDrive {
     } else {
       // retriving list of contents from root
       // in our case: list available drives
-      const drivesList: Contents.IModel[] = [];
+      const drivesListInfo: Contents.IModel[] = [];
       // fetch list of available drives
-      this._drivesList = await getDrivesList();
-      for (const drive of this._drivesList) {
-        drivesList.push({
-          name: drive.name,
-          path: drive.name,
-          last_modified: '',
-          created: drive.creationDate,
-          content: [],
-          format: 'json',
-          mimetype: '',
-          size: undefined,
-          writable: true,
-          type: 'directory'
-        });
+      try {
+        this._drivesList = await getDrivesList();
+        for (const drive of this._drivesList) {
+          drivesListInfo.push({
+            name: drive.name,
+            path: drive.name,
+            last_modified: '',
+            created: drive.creationDate,
+            content: [],
+            format: 'json',
+            mimetype: '',
+            size: undefined,
+            writable: true,
+            type: 'directory'
+          });
+        }
+      } catch (error) {
+        console.log(
+          'Failed loading available drives list, with error: ',
+          error
+        );
       }
 
       data = {
@@ -269,7 +276,7 @@ export class Drive implements Contents.IDrive {
         path: this._name,
         last_modified: '',
         created: '',
-        content: drivesList,
+        content: drivesListInfo,
         format: 'json',
         mimetype: '',
         size: undefined,

--- a/src/plugins/driveBrowserPlugin.ts
+++ b/src/plugins/driveBrowserPlugin.ts
@@ -333,7 +333,7 @@ namespace Private {
     app.commands.addCommand(CommandIDs.createNewDrive, {
       execute: async () => {
         return showDialog({
-          title: 'Create New Drive',
+          title: 'New Drive',
           body: new Private.CreateDriveHandler(drive.name),
           focusNodeSelector: 'input',
           buttons: [
@@ -349,14 +349,14 @@ namespace Private {
           }
         });
       },
-      label: 'Create New Drive',
+      label: 'New Drive',
       icon: driveBrowserIcon.bindprops({ stylesheet: 'menuItem' })
     });
 
     app.contextMenu.addItem({
       command: CommandIDs.createNewDrive,
       selector: '#drive-file-browser.jp-SidePanel .jp-DirListing-content',
-      rank: 10
+      rank: 100
     });
   }
 }

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -500,6 +500,39 @@ export const countObjectNameAppearances = async (
   return counter;
 };
 
+/**
+ * Create a new drive.
+ *
+ * @param newDriveName The new drive name.
+ * @param options.location The region where drive should be located.
+ *
+ * @returns A promise which resolves with the contents model.
+ */
+export async function createDrive(
+  newDriveName: string,
+  options: {
+    location: string;
+  }
+) {
+  await requestAPI<any>('drives/' + newDriveName + '/', 'POST', {
+    location: options.location
+  });
+
+  data = {
+    name: newDriveName,
+    path: newDriveName,
+    last_modified: '',
+    created: '',
+    content: [],
+    format: 'json',
+    mimetype: '',
+    size: 0,
+    writable: true,
+    type: 'directory'
+  };
+  return data;
+}
+
 namespace Private {
   /**
    * Helping function for renaming files inside

--- a/src/token.ts
+++ b/src/token.ts
@@ -8,6 +8,7 @@ export namespace CommandIDs {
   export const openDrivesDialog = 'drives:open-drives-dialog';
   export const openPath = 'drives:open-path';
   export const toggleBrowser = 'drives:toggle-main';
+  export const createNewDrive = 'drives:create-new-drive';
   export const launcher = 'launcher:create';
 }
 


### PR DESCRIPTION
Add drive handling operations, such as creating a new drive, deleting an existing drive and refreshing the list of available drives.

In order to create a new drive, a new context command was created which opens a dialog in which the user can specify the name of drive and the region in which it should be created. The drive is automatically created in `us-east-1`.

[Screencast from 13.01.2025 20:25:48.webm](https://github.com/user-attachments/assets/6ad66cfb-8012-46a7-b490-a9b4e5a54f5f)
