### PR TITLE
refresh drives config credentials using a timer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
         pip uninstall -y "jupyter_drives" jupyterlab
 
     - name: Upload extension packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: extension-artifacts
         path: dist/jupyter_drives*
@@ -69,7 +69,7 @@ jobs:
       with:
         python-version: '3.9'
         architecture: 'x64'
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: extension-artifacts
     - name: Install and Test
@@ -105,7 +105,7 @@ jobs:
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
     - name: Download extension package
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: extension-artifacts
 
@@ -139,7 +139,7 @@ jobs:
 
     - name: Upload Playwright Test report
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: jupyter_drives-playwright-tests
         path: |

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -20,7 +20,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Distributions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jupyter_drives-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist

--- a/jupyter_drives/base.py
+++ b/jupyter_drives/base.py
@@ -4,9 +4,13 @@ import entrypoints
 from traitlets import Enum, Unicode, default
 from traitlets.config import Configurable
 import boto3
+from tornado.ioloop import PeriodicCallback
 
 # Supported third-party services
 MANAGERS = {}
+
+# 15 minutes
+CREDENTIALS_REFRESH = 15 * 60 * 1000
 
 # Moved to the architecture of having one provider independent manager.
 # Keeping the loop in case of future developments that need this feature.
@@ -19,6 +23,7 @@ PROVIDERS = ['s3', 'gcs', 'http']
 class DrivesConfig(Configurable):
     """
     Allows configuration of supported drives via jupyter_notebook_config.py
+    Implements singleton pattern
     """
 
     session_token = Unicode(
@@ -48,7 +53,7 @@ class DrivesConfig(Configurable):
         allow_none=True,
         help = "Region name.",
     )
-    
+
     api_base_url = Unicode(
         config=True,
         help="Base URL of the provider service REST API.",
@@ -59,7 +64,7 @@ class DrivesConfig(Configurable):
         # for AWS S3 drives
         if self.provider == "s3":
             return "https://s3.amazonaws.com/" # region? https://s3.<region>.amazonaws.com/
-        
+
         # for Google Cloud Storage drives
         elif self.provider == "gcs":
             return "https://www.googleapis.com/"   
@@ -71,15 +76,34 @@ class DrivesConfig(Configurable):
         help="The source control provider.",
     )
 
+    _instance = None
+
+    def __new__(cls, **kwargs):
+        if cls._instance is None:
+            cls._instance = super(DrivesConfig, cls).__new__(cls)
+            cls._instance._initialized = False
+        return cls._instance
+
     def __init__(self, **kwargs):
+        if self._initialized:
+            return
+
         super().__init__(**kwargs)
-        self._load_credentials()
-    
-    def _load_credentials(self):  
+        self._initialize_credentials_refresh()
+        self._initialized = True
+
+    def _initialize_credentials_refresh(self):
         # check if credentials were already set in jupyter_notebook_config.py
         if self.access_key_id is not None and self.secret_access_key is not None:
             return
-        
+
+        self._load_credentials()
+        self._credential_refresh = PeriodicCallback(
+            self._load_credentials, CREDENTIALS_REFRESH
+        )
+        self._credential_refresh.start()
+
+    def _load_credentials(self):
         # automatically extract credentials for S3 drives
         try:
             s = boto3.Session()

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -230,10 +230,11 @@ export class Drive implements Contents.IDrive {
       // when accessed the first time, mount drive
       if (currentDrive.mounted === false) {
         try {
-          await mountDrive(localPath, {
+          const driveName = currentDrive.name;
+          await mountDrive(driveName, {
             provider: currentDrive.provider
           });
-          this._drivesList.filter(x => x.name === localPath)[0].mounted = true;
+          this._drivesList.filter(x => x.name === driveName)[0].mounted = true;
         } catch (e) {
           // it will give an error if drive is already mounted
         }


### PR DESCRIPTION
Addresses Issue #74 

- Initialize `_load_credentials` refresh every 15 minutes so that new boto credentials get picked up before they are expired. Botocore library takes care of renewing the credentials under the hood seamlessly, we just need to read the latest values before the token is expired. The token by default gets expired in 60 minutes.
- Make `DrivesConfig` class singleton so that we only have one refresh timer running at a single point of time
- Verified installing updated package in Sagemaker JupyterLab and once token expired in 60 minutes, S3 Browser extension continued to function as expected, i.e the credentials were refreshed successfully.
