### PR TITLE
Create new drive command visibility

### DIFF
--- a/schema/drives-file-browser.json
+++ b/schema/drives-file-browser.json
@@ -27,6 +27,12 @@
         "command": "drives:toggle-file-filter",
         "label": "",
         "rank": 40
+      },
+      {
+        "name": "new-drive",
+        "command": "drives:create-new-drive",
+        "label": "",
+        "rank": 50
       }
     ]
   },

--- a/src/plugins/driveBrowserPlugin.ts
+++ b/src/plugins/driveBrowserPlugin.ts
@@ -147,6 +147,14 @@ export const driveFileBrowser: JupyterFrontEndPlugin<void> = {
       }
     );
 
+    const updateVisibility = () => {
+      // Visibility of command changed.
+      app.commands.notifyCommandChanged(CommandIDs.createNewDrive);
+    };
+
+    // Listen for path changes.
+    driveBrowser.model.pathChanged.connect(updateVisibility);
+
     // Add commands
     Private.addCommands(app, drive, driveBrowser);
 


### PR DESCRIPTION
Show the `Create new drive` command only at root level in the context menu and add it as a button to the toolbar that has the same visibility behaviour. 

[Screencast from 27.06.2025 17:41:11.webm](https://github.com/user-attachments/assets/ac4768c2-351b-4011-9217-84111a2caa10)

Note: Icon of command is temporary and will be changed along with the drive browser icon. 