### PR TITLE
Update drive browser commands visbility

### DIFF
--- a/schema/drives-file-browser.json
+++ b/schema/drives-file-browser.json
@@ -59,6 +59,19 @@
         "command": "drives:create-new-directory",
         "selector": ".jp-DirListing-content",
         "rank": 55
+      },
+      {
+        "command": "notebook:create-new",
+        "selector": ".jp-DirListing-content",
+         "args": {
+      "isContextMenu": true
+    },
+        "disabled": true
+      },
+        {
+        "command": "drives:create-new-notebook",
+        "selector": ".jp-DirListing-content",
+        "rank": 54
       }
     ]
   },

--- a/schema/drives-file-browser.json
+++ b/schema/drives-file-browser.json
@@ -9,12 +9,6 @@
         "label": "",
         "rank": 1
       },
-      {
-        "name": "new-directory",
-        "command": "drives:create-new-directory",
-        "label": "",
-        "rank": 10
-      },
       { "name": "uploader", "label": "", "rank": 20 },
       {
         "name": "refresh",
@@ -63,12 +57,12 @@
       {
         "command": "notebook:create-new",
         "selector": ".jp-DirListing-content",
-         "args": {
-      "isContextMenu": true
-    },
+        "args": {
+          "isContextMenu": true
+        },
         "disabled": true
       },
-        {
+      {
         "command": "drives:create-new-notebook",
         "selector": ".jp-DirListing-content",
         "rank": 54

--- a/schema/drives-file-browser.json
+++ b/schema/drives-file-browser.json
@@ -31,7 +31,7 @@
         "name": "new-drive",
         "command": "drives:create-new-drive",
         "label": "",
-        "rank": 10
+        "rank": 5
       }
     ]
   },

--- a/schema/drives-file-browser.json
+++ b/schema/drives-file-browser.json
@@ -9,6 +9,11 @@
         "label": "",
         "rank": 1
       },
+      {
+        "name": "new-directory",
+        "command": "drives:create-new-directory",
+        "rank": 10
+      },
       { "name": "uploader", "label": "", "rank": 20 },
       {
         "name": "refresh",
@@ -26,7 +31,7 @@
         "name": "new-drive",
         "command": "drives:create-new-drive",
         "label": "",
-        "rank": 50
+        "rank": 10
       }
     ]
   },

--- a/schema/drives-file-browser.json
+++ b/schema/drives-file-browser.json
@@ -39,6 +39,17 @@
   "jupyter.lab.menus": {
     "context": [
       {
+        "command": "filebrowser:create-new-file",
+        "selector": ".jp-DirListing-content",
+        "rank": 51,
+        "disabled": true
+      },
+      {
+        "command": "drives:create-new-file",
+        "selector": ".jp-DirListing-content",
+        "rank": 51
+      },
+      {
         "command": "filebrowser:create-new-directory",
         "selector": ".jp-DirListing-content",
         "rank": 55,

--- a/schema/drives-file-browser.json
+++ b/schema/drives-file-browser.json
@@ -11,7 +11,7 @@
       },
       {
         "name": "new-directory",
-        "command": "filebrowser:create-new-directory",
+        "command": "drives:create-new-directory",
         "label": "",
         "rank": 10
       },
@@ -33,6 +33,21 @@
         "command": "drives:create-new-drive",
         "label": "",
         "rank": 50
+      }
+    ]
+  },
+  "jupyter.lab.menus": {
+    "context": [
+      {
+        "command": "filebrowser:create-new-directory",
+        "selector": ".jp-DirListing-content",
+        "rank": 55,
+        "disabled": true
+      },
+      {
+        "command": "drives:create-new-directory",
+        "selector": ".jp-DirListing-content",
+        "rank": 55
       }
     ]
   },

--- a/src/plugins/driveBrowserPlugin.ts
+++ b/src/plugins/driveBrowserPlugin.ts
@@ -157,6 +157,7 @@ export const driveFileBrowser: JupyterFrontEndPlugin<void> = {
       }
       app.commands.notifyCommandChanged(CommandIDs.createNewDrive);
       app.commands.notifyCommandChanged(CommandIDs.createNewDirectory);
+      app.commands.notifyCommandChanged(CommandIDs.launcher);
     };
 
     // Listen for path changes.

--- a/src/plugins/driveBrowserPlugin.ts
+++ b/src/plugins/driveBrowserPlugin.ts
@@ -121,12 +121,10 @@ export const driveFileBrowser: JupyterFrontEndPlugin<void> = {
       restorer.add(driveBrowser, 'drive-file-browser');
     }
 
-    toolbarRegistry.addFactory(
-      FILE_BROWSER_FACTORY,
-      'uploader',
-      (fileBrowser: FileBrowser) =>
-        new Uploader({ model: fileBrowser.model, translator })
-    );
+    const uploader = new Uploader({ model: driveBrowser.model, translator });
+    toolbarRegistry.addFactory(FILE_BROWSER_FACTORY, 'uploader', () => {
+      return uploader;
+    });
 
     toolbarRegistry.addFactory(
       FILE_BROWSER_FACTORY,
@@ -152,6 +150,11 @@ export const driveFileBrowser: JupyterFrontEndPlugin<void> = {
 
     const updateVisibility = () => {
       // Visibility of context menu and toolbar commands changed.
+      if (driveBrowser.model.path !== 's3:') {
+        uploader.show();
+      } else {
+        uploader.hide();
+      }
       app.commands.notifyCommandChanged(CommandIDs.createNewDrive);
       app.commands.notifyCommandChanged(CommandIDs.createNewDirectory);
     };

--- a/src/plugins/driveBrowserPlugin.ts
+++ b/src/plugins/driveBrowserPlugin.ts
@@ -113,6 +113,7 @@ export const driveFileBrowser: JupyterFrontEndPlugin<void> = {
     driveBrowser.title.icon = driveBrowserIcon;
     driveBrowser.title.caption = 'Drive File Browser';
     driveBrowser.id = 'drive-file-browser';
+    driveBrowser.addClass('drive-browser');
 
     void Private.restoreBrowser(driveBrowser, commands, router, tree, labShell);
 
@@ -154,9 +155,9 @@ export const driveFileBrowser: JupyterFrontEndPlugin<void> = {
     const updateVisibility = () => {
       // Visibility of context menu and toolbar commands changed.
       if (driveBrowser.model.path !== 's3:') {
-        uploader.show();
+        uploader.enabled = true;
       } else {
-        uploader.hide();
+        uploader.enabled = false;
       }
       app.commands.notifyCommandChanged(CommandIDs.createNewDrive);
       app.commands.notifyCommandChanged(CommandIDs.createNewDirectory);
@@ -335,7 +336,7 @@ namespace Private {
     browser: FileBrowser
   ): void {
     app.commands.addCommand(CommandIDs.createNewDrive, {
-      isVisible: () => {
+      isEnabled: () => {
         return browser.model.path === 's3:';
       },
       execute: async () => {
@@ -363,7 +364,7 @@ namespace Private {
     app.contextMenu.addItem({
       command: CommandIDs.createNewDrive,
       selector: '#drive-file-browser.jp-SidePanel .jp-DirListing-content',
-      rank: 100
+      rank: 105
     });
 
     app.commands.addCommand(CommandIDs.toggleFileFilter, {
@@ -381,7 +382,7 @@ namespace Private {
     });
 
     app.commands.addCommand(CommandIDs.createNewDirectory, {
-      isVisible: () => {
+      isEnabled: () => {
         return browser.model.path !== 's3:';
       },
       execute: () => {
@@ -392,7 +393,7 @@ namespace Private {
     });
 
     app.commands.addCommand(CommandIDs.createNewFile, {
-      isVisible: () => {
+      isEnabled: () => {
         return browser.model.path !== 's3:';
       },
       execute: () => {
@@ -403,7 +404,7 @@ namespace Private {
     });
 
     app.commands.addCommand(CommandIDs.createNewNotebook, {
-      isVisible: () => {
+      isEnabled: () => {
         return browser.model.path !== 's3:';
       },
       execute: () => {

--- a/src/plugins/driveBrowserPlugin.ts
+++ b/src/plugins/driveBrowserPlugin.ts
@@ -24,7 +24,8 @@ import {
   FilenameSearcher,
   IScore,
   newFolderIcon,
-  fileIcon
+  fileIcon,
+  notebookIcon
 } from '@jupyterlab/ui-components';
 import { CommandRegistry } from '@lumino/commands';
 import { Widget } from '@lumino/widgets';
@@ -379,7 +380,6 @@ namespace Private {
         return browser.model.path !== 's3:';
       },
       execute: () => {
-        console.log('NEW COMMAND DIR');
         app.commands.execute('filebrowser:create-new-directory');
       },
       icon: newFolderIcon.bindprops({ stylesheet: 'menuItem' }),
@@ -395,6 +395,17 @@ namespace Private {
       },
       icon: fileIcon.bindprops({ stylesheet: 'menuItem' }),
       label: 'New File'
+    });
+
+    app.commands.addCommand(CommandIDs.createNewNotebook, {
+      isVisible: () => {
+        return browser.model.path !== 's3:';
+      },
+      execute: () => {
+        app.commands.execute('notebook:create-new');
+      },
+      icon: notebookIcon.bindprops({ stylesheet: 'menuItem' }),
+      label: 'New Notebook'
     });
   }
 }

--- a/src/plugins/driveBrowserPlugin.ts
+++ b/src/plugins/driveBrowserPlugin.ts
@@ -23,7 +23,8 @@ import {
   filterIcon,
   FilenameSearcher,
   IScore,
-  newFolderIcon
+  newFolderIcon,
+  fileIcon
 } from '@jupyterlab/ui-components';
 import { CommandRegistry } from '@lumino/commands';
 import { Widget } from '@lumino/widgets';
@@ -383,6 +384,17 @@ namespace Private {
       },
       icon: newFolderIcon.bindprops({ stylesheet: 'menuItem' }),
       label: 'New Folder'
+    });
+
+    app.commands.addCommand(CommandIDs.createNewFile, {
+      isVisible: () => {
+        return browser.model.path !== 's3:';
+      },
+      execute: () => {
+        app.commands.execute('filebrowser:create-new-file');
+      },
+      icon: fileIcon.bindprops({ stylesheet: 'menuItem' }),
+      label: 'New File'
     });
   }
 }

--- a/src/plugins/driveBrowserPlugin.ts
+++ b/src/plugins/driveBrowserPlugin.ts
@@ -148,6 +148,9 @@ export const driveFileBrowser: JupyterFrontEndPlugin<void> = {
       }
     );
 
+    // Add commands
+    Private.addCommands(app, drive, driveBrowser);
+
     const updateVisibility = () => {
       // Visibility of context menu and toolbar commands changed.
       if (driveBrowser.model.path !== 's3:') {
@@ -162,9 +165,7 @@ export const driveFileBrowser: JupyterFrontEndPlugin<void> = {
 
     // Listen for path changes.
     driveBrowser.model.pathChanged.connect(updateVisibility);
-
-    // Add commands
-    Private.addCommands(app, drive, driveBrowser);
+    updateVisibility();
 
     // Connect the filebrowser toolbar to the settings registry for the plugin.
     setToolbar(

--- a/src/plugins/driveBrowserPlugin.ts
+++ b/src/plugins/driveBrowserPlugin.ts
@@ -22,7 +22,8 @@ import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import {
   filterIcon,
   FilenameSearcher,
-  IScore
+  IScore,
+  newFolderIcon
 } from '@jupyterlab/ui-components';
 import { CommandRegistry } from '@lumino/commands';
 import { Widget } from '@lumino/widgets';
@@ -148,8 +149,9 @@ export const driveFileBrowser: JupyterFrontEndPlugin<void> = {
     );
 
     const updateVisibility = () => {
-      // Visibility of command changed.
+      // Visibility of context menu and toolbar commands changed.
       app.commands.notifyCommandChanged(CommandIDs.createNewDrive);
+      app.commands.notifyCommandChanged(CommandIDs.createNewDirectory);
     };
 
     // Listen for path changes.
@@ -369,6 +371,18 @@ namespace Private {
       },
       icon: filterIcon.bindprops({ stylesheet: 'menuItem' }),
       label: 'Toggle File Filter'
+    });
+
+    app.commands.addCommand(CommandIDs.createNewDirectory, {
+      isVisible: () => {
+        return browser.model.path !== 's3:';
+      },
+      execute: () => {
+        console.log('NEW COMMAND DIR');
+        app.commands.execute('filebrowser:create-new-directory');
+      },
+      icon: newFolderIcon.bindprops({ stylesheet: 'menuItem' }),
+      label: 'New Folder'
     });
   }
 }

--- a/src/plugins/launcherPlugin.ts
+++ b/src/plugins/launcherPlugin.ts
@@ -44,6 +44,10 @@ function activate(
   commands.addCommand(CommandIDs.launcher, {
     label: trans.__('New Launcher'),
     icon: args => (args.toolbar ? addIcon : undefined),
+    isEnabled: () => {
+      const currentBrowser = factory?.tracker.currentWidget;
+      return currentBrowser?.model.path !== 's3:';
+    },
     execute: (args: ReadonlyPartialJSONObject) => {
       // get current file browser used
       const currentBrowser = factory?.tracker.currentWidget;

--- a/src/token.ts
+++ b/src/token.ts
@@ -11,6 +11,7 @@ export namespace CommandIDs {
   export const launcher = 'launcher:create';
   export const toggleFileFilter = 'drives:toggle-file-filter';
   export const createNewDirectory = 'drives:create-new-directory';
+  export const createNewFile = 'drives:create-new-file';
 }
 
 /**

--- a/src/token.ts
+++ b/src/token.ts
@@ -12,6 +12,7 @@ export namespace CommandIDs {
   export const toggleFileFilter = 'drives:toggle-file-filter';
   export const createNewDirectory = 'drives:create-new-directory';
   export const createNewFile = 'drives:create-new-file';
+  export const createNewNotebook = 'drives:create-new-notebook';
 }
 
 /**

--- a/src/token.ts
+++ b/src/token.ts
@@ -10,6 +10,7 @@ export namespace CommandIDs {
   export const createNewDrive = 'drives:create-new-drive';
   export const launcher = 'launcher:create';
   export const toggleFileFilter = 'drives:toggle-file-filter';
+  export const createNewDirectory = 'drives:create-new-directory';
 }
 
 /**

--- a/style/base.css
+++ b/style/base.css
@@ -3,6 +3,10 @@
 
     https://jupyterlab.readthedocs.io/en/stable/developer/css.html
 */
+.drive-browser {
+  min-width: 285px !important;
+}
+
 li {
   list-style-type: none;
 }


### PR DESCRIPTION
As at root level for the drive browser the user sees a list of available drives, certain commands cannot be performed.

This PR updates the drive browser toolbar and context menu commands, such that, at root level the following commands are disabled: 
-  `New Directory`
- `Upload`
- `New File`
- `New Notebook`
- `Launcher`,

and when entering a bucket the `New Drive` functionality is disabled.

**Root level**

![image](https://github.com/user-attachments/assets/53129bec-9daf-4e3d-824f-f16a4b295fff)

**Inside drive**

![image](https://github.com/user-attachments/assets/84e22087-f88f-41bf-bf3f-d22a86a8d41c)
