### PR TITLE
Add support for including and excluding drives from listing

### DIFF
--- a/jupyter_drives/handlers.py
+++ b/jupyter_drives/handlers.py
@@ -52,7 +52,10 @@ class ConfigJupyterDrivesHandler(JupyterDrivesAPIHandler):
     @tornado.web.authenticated
     async def post(self):
         body = self.get_json_body()
-        result = self._manager.set_listing_limit(**body)
+        if 'new_limit' in body:
+            result = self._manager.set_listing_limit(**body)
+        if 'exclude_drive_name' in body:
+            result = self._manager.exclude_drive(**body)
         self.finish(result)
 
 class ListJupyterDrivesHandler(JupyterDrivesAPIHandler):

--- a/jupyter_drives/handlers.py
+++ b/jupyter_drives/handlers.py
@@ -56,6 +56,8 @@ class ConfigJupyterDrivesHandler(JupyterDrivesAPIHandler):
             result = self._manager.set_listing_limit(**body)
         if 'exclude_drive_name' in body:
             result = self._manager.exclude_drive(**body)
+        if 'include_drive_name' in body:
+            result = self._manager.include_drive(**body)
         self.finish(result)
 
 class ListJupyterDrivesHandler(JupyterDrivesAPIHandler):

--- a/jupyter_drives/handlers.py
+++ b/jupyter_drives/handlers.py
@@ -50,6 +50,11 @@ class ConfigJupyterDrivesHandler(JupyterDrivesAPIHandler):
         return super().initialize(logger, manager)
     
     @tornado.web.authenticated
+    async def get(self):
+        result = self._manager.get_excluded_drives()
+        self.finish(json.dumps(result["data"]))
+
+    @tornado.web.authenticated
     async def post(self):
         body = self.get_json_body()
         if 'new_limit' in body:

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -207,7 +207,7 @@ class JupyterDrivesManager():
             except Exception as e:
                 raise tornado.web.HTTPError(
                     status_code=httpx.codes.BAD_REQUEST,
-                    reason=f"The following error occured when listing excluded drives: {e}",
+                    reason=f"The following error occurred when listing excluded drives: {e}",
                 )
         
         response = {
@@ -226,7 +226,7 @@ class JupyterDrivesManager():
         except Exception as e:
             raise tornado.web.HTTPError(
             status_code= httpx.codes.BAD_REQUEST,
-            reason= f"The following error occured when including the drive: {e}"
+            reason= f"The following error occurred when including the drive: {e}"
             )
 
         return

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -188,6 +188,33 @@ class JupyterDrivesManager():
 
         return
     
+    def get_excluded_drives(self):
+        """Get list of excluded drives.
+
+        Returns: 
+            List of excluded drives and their properties.
+        """
+        data = []
+        for drive in self._excluded_drives:
+            try:
+                data.append({
+                    "name": drive,
+                    "region": self._config.region_name,
+                    "creationDate": datetime.now().isoformat(timespec='milliseconds').replace('+00:00', 'Z'),
+                    "mounted": False if drive not in self._content_managers else True,
+                    "provider": self._config.provider
+                })
+            except Exception as e:
+                raise tornado.web.HTTPError(
+                    status_code=httpx.codes.BAD_REQUEST,
+                    reason=f"The following error occured when listing excluded drives: {e}",
+                )
+        
+        response = {
+            "data": data
+        }
+        return response
+    
     def include_drive(self, include_drive_name):
         """Include drive in listing.
 

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -188,6 +188,22 @@ class JupyterDrivesManager():
 
         return
     
+    def include_drive(self, include_drive_name):
+        """Include drive in listing.
+
+        Args:
+            include_bucket_name: drive to include in listing
+        """
+        try:
+            self._excluded_drives.remove(include_drive_name);
+        except Exception as e:
+            raise tornado.web.HTTPError(
+            status_code= httpx.codes.BAD_REQUEST,
+            reason= f"The following error occured when excluding the drive: {e}"
+            )
+
+        return
+    
     async def list_drives(self): 
         """Get list of available drives.
 

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -270,13 +270,14 @@ class JupyterDrivesManager():
             if len(self._external_drives) != 0:
                 for drive in self._external_drives.values():
                     try:
-                        data.append({
-                            "name": drive['url'],
-                            "region": self._config.region_name if drive['url'] not in self._content_managers else self._content_managers[drive['url']]["location"],
-                            "creationDate": datetime.now().isoformat(timespec='milliseconds').replace('+00:00', 'Z'),
-                            "mounted": False if result.name not in self._content_managers else True,
-                            "provider": self._config.provider
-                        })
+                        if drive['url'] not in self._excluded_drives:
+                            data.append({
+                                "name": drive['url'],
+                                "region": self._config.region_name if drive['url'] not in self._content_managers else self._content_managers[drive['url']]["location"],
+                                "creationDate": datetime.now().isoformat(timespec='milliseconds').replace('+00:00', 'Z'),
+                                "mounted": False if result.name not in self._content_managers else True,
+                                "provider": self._config.provider
+                            })
                     except Exception as e:
                         raise tornado.web.HTTPError(
                             status_code=httpx.codes.BAD_REQUEST,

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -199,7 +199,7 @@ class JupyterDrivesManager():
             try:
                 data.append({
                     "name": drive,
-                    "region": self._config.region_name,
+                    "region": self._config.region_name if drive not in self._content_managers else self._content_managers[drive]["location"],
                     "creationDate": datetime.now().isoformat(timespec='milliseconds').replace('+00:00', 'Z'),
                     "mounted": False if drive not in self._content_managers else True,
                     "provider": self._config.provider
@@ -260,7 +260,7 @@ class JupyterDrivesManager():
                     data.append(
                         {
                             "name": result.name,
-                            "region": self._config.region_name,
+                            "region": self._config.region_name if result.name not in self._content_managers else self._content_managers[result.name]["location"],
                             "creationDate": result.extra["creation_date"],
                             "mounted": False if result.name not in self._content_managers else True,
                             "provider": self._config.provider
@@ -272,7 +272,7 @@ class JupyterDrivesManager():
                     try:
                         data.append({
                             "name": drive['url'],
-                            "region": self._config.region_name,
+                            "region": self._config.region_name if drive['url'] not in self._content_managers else self._content_managers[drive['url']]["location"],
                             "creationDate": datetime.now().isoformat(timespec='milliseconds').replace('+00:00', 'Z'),
                             "mounted": False if result.name not in self._content_managers else True,
                             "provider": self._config.provider

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -199,7 +199,7 @@ class JupyterDrivesManager():
         except Exception as e:
             raise tornado.web.HTTPError(
             status_code= httpx.codes.BAD_REQUEST,
-            reason= f"The following error occured when excluding the drive: {e}"
+            reason= f"The following error occured when including the drive: {e}"
             )
 
         return

--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -53,6 +53,7 @@ class JupyterDrivesManager():
         self._max_files_listed = 1025
         self._drives = None
         self._external_drives = {}
+        self._excluded_drives = set()
         
         # instate fsspec file system
         self._file_system = fsspec.filesystem(self._config.provider, asynchronous=True)
@@ -171,6 +172,22 @@ class JupyterDrivesManager():
 
         return
     
+    def exclude_drive(self, exclude_drive_name):
+        """Exclude drive from listing.
+
+        Args:
+            exclude_bucket_name: drive to exclude
+        """
+        try:
+            self._excluded_drives.add(exclude_drive_name);
+        except Exception as e:
+            raise tornado.web.HTTPError(
+            status_code= httpx.codes.BAD_REQUEST,
+            reason= f"The following error occured when excluding the drive: {e}"
+            )
+
+        return
+    
     async def list_drives(self): 
         """Get list of available drives.
 
@@ -196,15 +213,16 @@ class JupyterDrivesManager():
                     )
             
             for result in results:
-                data.append(
-                    {
-                        "name": result.name,
-                        "region": self._config.region_name,
-                        "creationDate": result.extra["creation_date"],
-                        "mounted": False if result.name not in self._content_managers else True,
-                        "provider": self._config.provider
-                    }
-                )
+                if result.name not in self._excluded_drives:
+                    data.append(
+                        {
+                            "name": result.name,
+                            "region": self._config.region_name,
+                            "creationDate": result.extra["creation_date"],
+                            "mounted": False if result.name not in self._content_managers else True,
+                            "provider": self._config.provider
+                        }
+                    )
             
             if len(self._external_drives) != 0:
                 for drive in self._external_drives.values():

--- a/schema/drives-file-browser.json
+++ b/schema/drives-file-browser.json
@@ -28,8 +28,8 @@
         "rank": 40
       },
       {
-        "name": "new-drive",
-        "command": "drives:create-new-drive",
+        "name": "drives-manager",
+        "command": "drives:open-drives-dialog",
         "label": "",
         "rank": 5
       }

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -697,9 +697,9 @@ export class Drive implements Contents.IDrive {
 
     Contents.validateContentsModel(data);
     this._fileChanged.emit({
-      type: 'new',
-      oldValue: null,
-      newValue: data
+      type: 'delete',
+      oldValue: data,
+      newValue: null
     });
 
     return data;

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -688,11 +688,31 @@ export class Drive implements Contents.IDrive {
    * Exclude drive from browser.
    *
    * @param driveName: The name of drive to exclude.
-   * 
+   *
    * @returns A promise which resolves with the contents model.
    */
   async excludeDrive(driveName: string): Promise<Contents.IModel> {
     data = await excludeDrive(driveName);
+
+    Contents.validateContentsModel(data);
+    this._fileChanged.emit({
+      type: 'new',
+      oldValue: null,
+      newValue: data
+    });
+
+    return data;
+  }
+
+  /**
+   * Include drive in browser listing.
+   *
+   * @param driveName: The name of drive to include.
+   *
+   * @returns A promise which resolves with the contents model.
+   */
+  async includeDrive(driveName: string): Promise<Contents.IModel> {
+    data = await this.includeDrive(driveName);
 
     Contents.validateContentsModel(data);
     this._fileChanged.emit({

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -22,7 +22,8 @@ import {
   copyObjects,
   presignedLink,
   createDrive,
-  getDrivesList
+  getDrivesList,
+  excludeDrive
 } from './requests';
 
 let data: Contents.IModel = {
@@ -672,6 +673,26 @@ export class Drive implements Contents.IDrive {
    */
   async addPublicDrive(driveUrl: string): Promise<Contents.IModel> {
     data = await addPublicDrive(driveUrl);
+
+    Contents.validateContentsModel(data);
+    this._fileChanged.emit({
+      type: 'new',
+      oldValue: null,
+      newValue: data
+    });
+
+    return data;
+  }
+
+  /**
+   * Exclude drive from browser.
+   *
+   * @param driveName: The name of drive to exclude.
+   * 
+   * @returns A promise which resolves with the contents model.
+   */
+  async excludeDrive(driveName: string): Promise<Contents.IModel> {
+    data = await excludeDrive(driveName);
 
     Contents.validateContentsModel(data);
     this._fileChanged.emit({

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -23,7 +23,8 @@ import {
   presignedLink,
   createDrive,
   getDrivesList,
-  excludeDrive
+  excludeDrive,
+  includeDrive
 } from './requests';
 
 let data: Contents.IModel = {
@@ -712,7 +713,7 @@ export class Drive implements Contents.IDrive {
    * @returns A promise which resolves with the contents model.
    */
   async includeDrive(driveName: string): Promise<Contents.IModel> {
-    data = await this.includeDrive(driveName);
+    data = await includeDrive(driveName);
 
     Contents.validateContentsModel(data);
     this._fileChanged.emit({

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -1,7 +1,13 @@
 import { LabIcon } from '@jupyterlab/ui-components';
 import driveBrowserSvg from '../style/driveIconFileBrowser.svg';
+import addIconSvg from '../style/addIcon.svg';
 
 export const driveBrowserIcon = new LabIcon({
   name: 'jupyter-drives:drive-browser',
   svgstr: driveBrowserSvg
+});
+
+export const addIcon = new LabIcon({
+  name: 'jupyter-drives:add-drive',
+  svgstr: addIconSvg
 });

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -1,6 +1,7 @@
 import { LabIcon } from '@jupyterlab/ui-components';
 import driveBrowserSvg from '../style/driveIconFileBrowser.svg';
 import addIconSvg from '../style/addIcon.svg';
+import removeIconSvg from '../style/removeIcon.svg';
 
 export const driveBrowserIcon = new LabIcon({
   name: 'jupyter-drives:drive-browser',
@@ -10,4 +11,9 @@ export const driveBrowserIcon = new LabIcon({
 export const addIcon = new LabIcon({
   name: 'jupyter-drives:add-drive',
   svgstr: addIconSvg
+});
+
+export const removeIcon = new LabIcon({
+  name: 'jupyter-drives:remove-drive',
+  svgstr: removeIconSvg
 });

--- a/src/plugins/driveBrowserPlugin.ts
+++ b/src/plugins/driveBrowserPlugin.ts
@@ -33,7 +33,7 @@ import { PageConfig, PathExt } from '@jupyterlab/coreutils';
 import { CommandRegistry } from '@lumino/commands';
 import { Widget } from '@lumino/widgets';
 
-import { addIcon, driveBrowserIcon, removeIcon } from '../icons';
+import { driveBrowserIcon, removeIcon } from '../icons';
 import { Drive } from '../contents';
 import { setListingLimit } from '../requests';
 import { CommandIDs } from '../token';
@@ -568,38 +568,6 @@ namespace Private {
       command: CommandIDs.excludeDrive,
       selector:
         '#drive-file-browser.jp-SidePanel .jp-DirListing-content .jp-DirListing-item[data-isdir]',
-      rank: 110
-    });
-
-    app.commands.addCommand(CommandIDs.includeDrive, {
-      isVisible: () => {
-        return browser.model.path === 's3:';
-      },
-      execute: async () => {
-        return showDialog({
-          title: 'Include Drive',
-          body: new Private.AddPublicDriveHandler(drive.name),
-          focusNodeSelector: 'input',
-          buttons: [
-            Dialog.cancelButton(),
-            Dialog.okButton({
-              label: 'Add',
-              ariaLabel: 'Include Drive'
-            })
-          ]
-        }).then(async result => {
-          if (result.value) {
-            await drive.includeDrive(result.value);
-          }
-        });
-      },
-      label: 'Include Drive',
-      icon: addIcon.bindprops({ stylesheet: 'menuItem' })
-    });
-
-    app.contextMenu.addItem({
-      command: CommandIDs.includeDrive,
-      selector: '#drive-file-browser.jp-SidePanel .jp-DirListing-content',
       rank: 110
     });
   }

--- a/src/plugins/driveBrowserPlugin.ts
+++ b/src/plugins/driveBrowserPlugin.ts
@@ -560,7 +560,7 @@ namespace Private {
         const driveName: string = item.value.name;
         await drive.excludeDrive(driveName);
       },
-      label: 'Exclude Drive',
+      label: 'Remove Drive',
       icon: removeIcon.bindprops({ stylesheet: 'menuItem' })
     });
 

--- a/src/plugins/driveBrowserPlugin.ts
+++ b/src/plugins/driveBrowserPlugin.ts
@@ -547,7 +547,7 @@ namespace Private {
       isVisible: () => {
         return browser.model.path === 's3:';
       },
-      execute: () => {
+      execute: async () => {
         const widget = tracker.currentWidget;
         if (!widget) {
           return;
@@ -558,7 +558,7 @@ namespace Private {
         }
 
         const driveName: string = item.value.name;
-        drive.excludeDrive(driveName);
+        await drive.excludeDrive(driveName);
       },
       label: 'Exclude Drive',
       icon: removeIcon.bindprops({ stylesheet: 'menuItem' })
@@ -587,9 +587,9 @@ namespace Private {
               ariaLabel: 'Include Drive'
             })
           ]
-        }).then(result => {
+        }).then(async result => {
           if (result.value) {
-            drive.includeDrive(result.value);
+            await drive.includeDrive(result.value);
           }
         });
       },

--- a/src/plugins/driveBrowserPlugin.ts
+++ b/src/plugins/driveBrowserPlugin.ts
@@ -33,7 +33,7 @@ import { PageConfig, PathExt } from '@jupyterlab/coreutils';
 import { CommandRegistry } from '@lumino/commands';
 import { Widget } from '@lumino/widgets';
 
-import { driveBrowserIcon } from '../icons';
+import { addIcon, driveBrowserIcon, removeIcon } from '../icons';
 import { Drive } from '../contents';
 import { setListingLimit } from '../requests';
 import { CommandIDs } from '../token';
@@ -561,7 +561,7 @@ namespace Private {
         drive.excludeDrive(driveName);
       },
       label: 'Exclude Drive',
-      icon: driveBrowserIcon.bindprops({ stylesheet: 'menuItem' })
+      icon: removeIcon.bindprops({ stylesheet: 'menuItem' })
     });
 
     app.contextMenu.addItem({
@@ -594,7 +594,7 @@ namespace Private {
         });
       },
       label: 'Include Drive',
-      icon: driveBrowserIcon.bindprops({ stylesheet: 'menuItem' })
+      icon: addIcon.bindprops({ stylesheet: 'menuItem' })
     });
 
     app.contextMenu.addItem({

--- a/src/plugins/driveBrowserPlugin.ts
+++ b/src/plugins/driveBrowserPlugin.ts
@@ -542,5 +542,65 @@ namespace Private {
       icon: fileIcon.bindprops({ stylesheet: 'menuItem' }),
       label: 'Copy Path'
     });
+
+    app.commands.addCommand(CommandIDs.excludeDrive, {
+      isEnabled: () => {
+        return browser.model.path === 's3:';
+      },
+      execute: () => {
+        const widget = tracker.currentWidget;
+        if (!widget) {
+          return;
+        }
+        const item = widget.selectedItems().next();
+        if (item.done) {
+          return;
+        }
+
+        const driveName: string = item.value.name;
+        drive.excludeDrive(driveName);
+      },
+      label: 'Exclude Drive',
+      icon: driveBrowserIcon.bindprops({ stylesheet: 'menuItem' })
+    });
+
+    app.contextMenu.addItem({
+      command: CommandIDs.excludeDrive,
+      selector:
+        '#drive-file-browser.jp-SidePanel .jp-DirListing-content .jp-DirListing-item[data-isdir]',
+      rank: 110
+    });
+
+    app.commands.addCommand(CommandIDs.includeDrive, {
+      isEnabled: () => {
+        return browser.model.path === 's3:';
+      },
+      execute: async () => {
+        return showDialog({
+          title: 'Include Drive',
+          body: new Private.AddPublicDriveHandler(drive.name),
+          focusNodeSelector: 'input',
+          buttons: [
+            Dialog.cancelButton(),
+            Dialog.okButton({
+              label: 'Add',
+              ariaLabel: 'Include Drive'
+            })
+          ]
+        }).then(result => {
+          if (result.value) {
+            drive.includeDrive(result.value);
+          }
+        });
+      },
+      label: 'Include Drive',
+      icon: driveBrowserIcon.bindprops({ stylesheet: 'menuItem' })
+    });
+
+    app.contextMenu.addItem({
+      command: CommandIDs.includeDrive,
+      selector: '#drive-file-browser.jp-SidePanel .jp-DirListing-content',
+      rank: 110
+    });
   }
 }

--- a/src/plugins/driveBrowserPlugin.ts
+++ b/src/plugins/driveBrowserPlugin.ts
@@ -423,7 +423,7 @@ namespace Private {
     });
 
     app.commands.addCommand(CommandIDs.addPublicDrive, {
-      isEnabled: () => {
+      isVisible: () => {
         return browser.model.path === 's3:';
       },
       execute: async () => {
@@ -544,7 +544,7 @@ namespace Private {
     });
 
     app.commands.addCommand(CommandIDs.excludeDrive, {
-      isEnabled: () => {
+      isVisible: () => {
         return browser.model.path === 's3:';
       },
       execute: () => {
@@ -572,7 +572,7 @@ namespace Private {
     });
 
     app.commands.addCommand(CommandIDs.includeDrive, {
-      isEnabled: () => {
+      isVisible: () => {
         return browser.model.path === 's3:';
       },
       execute: async () => {

--- a/src/plugins/driveDialogPlugin.ts
+++ b/src/plugins/driveDialogPlugin.ts
@@ -74,11 +74,5 @@ export const openDriveDialogPlugin: JupyterFrontEndPlugin<void> = {
       caption: trans.__('Manage drives listed in filebrowser.'),
       label: trans.__('Manage listed drives')
     });
-
-    app.contextMenu.addItem({
-      command: CommandIDs.openDrivesDialog,
-      selector: '#drive-file-browser.jp-SidePanel',
-      rank: 100
-    });
   }
 };

--- a/src/plugins/drivelistmanager.tsx
+++ b/src/plugins/drivelistmanager.tsx
@@ -20,21 +20,32 @@ interface IProps {
 export interface IDriveInputProps {
   isName: boolean;
   value: string;
-  getValue: (event: any) => void;
+  setPublicDrive: (value: string) => void;
+  onSubmit: () => void;
 }
 
-export function DriveInputComponent(props: IDriveInputProps) {
+export function DriveInputComponent({
+  value,
+  setPublicDrive,
+  onSubmit
+}: IDriveInputProps) {
   return (
     <div>
       <div className="add-public-drive-section">
-        <Search
+        <input
           className="drive-search-input"
-          onInput={props.getValue}
+          onInput={(event: any) => {
+            setPublicDrive(event.target.value);
+          }}
           placeholder="Enter drive name"
+          value={value}
         />
         <Button
           className="input-add-drive-button"
-          onClick={() => addPublicDrive(props.value)}
+          onClick={() => {
+            onSubmit();
+            setPublicDrive('');
+          }}
         >
           add
         </Button>
@@ -135,7 +146,7 @@ export function DriveDataGridComponent(props: IDriveDataGridProps) {
 }
 
 export function DriveListManagerComponent({ model }: IProps) {
-  const [driveUrl, setDriveUrl] = useState('');
+  const [publicDrive, setPublicDrive] = useState('');
   const [searchDrive, setSearchDrive] = useState('');
   const [selectedDrives, setSelectedDrives] = useState<Partial<IDriveInfo>[]>(
     model.selectedDrives
@@ -156,8 +167,12 @@ export function DriveListManagerComponent({ model }: IProps) {
     });
   }, [model]);
 
-  const getValue = (event: any) => {
-    setDriveUrl(event.target.value);
+  const onAddedPublicDrive = async () => {
+    console.log(publicDrive);
+    await addPublicDrive(publicDrive);
+    setPublicDrive('');
+    console.log('publicDrve: ', publicDrive);
+    await model.refresh();
   };
 
   return (
@@ -185,8 +200,9 @@ export function DriveListManagerComponent({ model }: IProps) {
           <div className="drives-section-title"> Add public drive</div>
           <DriveInputComponent
             isName={false}
-            value={driveUrl}
-            getValue={getValue}
+            value={publicDrive}
+            setPublicDrive={setPublicDrive}
+            onSubmit={onAddedPublicDrive}
           />
         </div>
 

--- a/src/plugins/drivelistmanager.tsx
+++ b/src/plugins/drivelistmanager.tsx
@@ -1,22 +1,17 @@
 import * as React from 'react';
 import { VDomModel, VDomRenderer } from '@jupyterlab/ui-components';
-import {
-  Button,
-  DataGrid,
-  DataGridCell,
-  DataGridRow,
-  Search
-} from '@jupyter/react-components';
+import { Button, Search } from '@jupyter/react-components';
 import { useState } from 'react';
 import { IDriveInfo } from '../token';
 import {
   addPublicDrive,
+  excludeDrive,
   getDrivesList,
   getExcludedDrives,
   includeDrive
 } from '../requests';
 import { ISignal, Signal } from '@lumino/signaling';
-import { driveBrowserIcon, addIcon } from '../icons';
+import { driveBrowserIcon, addIcon, removeIcon } from '../icons';
 
 interface IProps {
   model: DriveListModel;
@@ -103,38 +98,38 @@ export function DriveSearchListComponent(props: ISearchListProps) {
 }
 interface IDriveDataGridProps {
   drives: Partial<IDriveInfo>[];
+  model: DriveListModel;
 }
 
 export function DriveDataGridComponent(props: IDriveDataGridProps) {
   return (
-    <div className="drive-data-grid">
-      <DataGrid grid-template-columns="1f 1fr">
-        <DataGridRow row-type="header">
-          <DataGridCell className="data-grid-cell" grid-column="1">
-            <b> name </b>
-          </DataGridCell>
-          <DataGridCell className="data-grid-cell-secondary" grid-column="2">
-            <b> region </b>
-          </DataGridCell>
-          <DataGridCell className="data-grid-cell-button" grid-column="3" />
-        </DataGridRow>
-
-        {props.drives.map((item, index) => (
-          <DataGridRow key={item.name} row-type="default">
-            <DataGridCell className="data-grid-cell" grid-column="1">
-              {item.name}
-            </DataGridCell>
-            <DataGridCell className="data-grid-cell-secondary" grid-column="2">
-              {item.region}
-            </DataGridCell>
-            <DataGridCell className="data-grid-cell-button" grid-column="3">
-              <Button className="input-add-drive-button" onClick={() => {}}>
-                add
+    <div className="drive-search-list">
+      {props.drives.length === 0 ? (
+        <div className="drives-manager-header-info">
+          {'No selected drives.'}
+        </div>
+      ) : (
+        props.drives.map((drive, index) => (
+          <li key={index}>
+            <div className="available-drives-section">
+              <div>{drive.name} </div>
+              <Button
+                className="search-add-drive-button"
+                onClick={async () => {
+                  await excludeDrive(drive.name!);
+                  await props.model.refresh();
+                }}
+              >
+                <removeIcon.react
+                  tag="span"
+                  className="available-drives-icon"
+                  height="18px"
+                />
               </Button>
-            </DataGridCell>
-          </DataGridRow>
-        ))}
-      </DataGrid>
+            </div>
+          </li>
+        ))
+      )}
     </div>
   );
 }
@@ -180,9 +175,10 @@ export function DriveListManagerComponent({ model }: IProps) {
           </div>
         </div>
       </span>
-      <div className="row">
+      <div>
         <div className="drives-manager-section">
-          <DriveDataGridComponent drives={selectedDrives} />
+          <div className="drives-section-title">Selected drives</div>
+          <DriveDataGridComponent drives={selectedDrives} model={model} />
         </div>
 
         <div className="drives-manager-section">

--- a/src/plugins/drivelistmanager.tsx
+++ b/src/plugins/drivelistmanager.tsx
@@ -15,16 +15,11 @@ import { ISignal, Signal } from '@lumino/signaling';
 interface IProps {
   model: DriveListModel;
 }
-// export interface IDrive {
-//   name: string;
-//   url: string;
-// }
 
 export interface IDriveInputProps {
   isName: boolean;
   value: string;
   getValue: (event: any) => void;
-  // updateSelectedDrives: (item: string, isName: boolean) => void;
 }
 export function DriveInputComponent(props: IDriveInputProps) {
   return (
@@ -34,12 +29,7 @@ export function DriveInputComponent(props: IDriveInputProps) {
           <Search className="drive-search-input" onInput={props.getValue} />
         </div>
         <div className="column"></div>
-        <Button
-          className="input-add-drive-button"
-          onClick={() => {
-            // props.updateSelectedDrives(props.value, props.isName);
-          }}
-        >
+        <Button className="input-add-drive-button" onClick={() => {}}>
           add
         </Button>
       </div>
@@ -49,10 +39,8 @@ export function DriveInputComponent(props: IDriveInputProps) {
 interface ISearchListProps {
   isName: boolean;
   value: string;
-  // filteredList: Array<string>;
   setValue: (value: any) => void;
   availableDrives: Partial<IDriveInfo>[];
-  // updateSelectedDrives: (item: string, isName: boolean) => void;
   model: DriveListModel;
 }
 
@@ -86,7 +74,6 @@ export function DriveSearchListComponent(props: ISearchListProps) {
                   onClick={async () => {
                     await includeDrive(drive.name!);
                     await props.model.refresh();
-                    // props.updateSelectedDrives(item, true);
                   }}
                 >
                   add
@@ -133,15 +120,12 @@ export function DriveDataGridComponent(props: IDriveDataGridProps) {
 export function DriveListManagerComponent({ model }: IProps) {
   const [driveUrl, setDriveUrl] = useState('');
   const [searchDrive, setSearchDrive] = useState('');
-  // let updatedSelectedDrives = [...model.selectedDrives];
   const [selectedDrives, setSelectedDrives] = useState<Partial<IDriveInfo>[]>(
     model.selectedDrives
   );
   const [availableDrives, setAvailableDrives] = useState<Partial<IDriveInfo>[]>(
     model.availableDrives
   );
-  // const [drivesFilteredList, setDrivesFilteredList] = useState<Partial<IDriveInfo>[]>(availableDrives);
-  // const nameList: Array<string> = [];
 
   // Called after mounting.
   React.useEffect(() => {
@@ -155,30 +139,9 @@ export function DriveListManagerComponent({ model }: IProps) {
     });
   }, [model]);
 
-  // for (const item of availableDrives) {
-  //   if (item.name !== '') {
-  //     nameList.push(item.name!);
-  //   }
-  // }
-
   const getValue = (event: any) => {
     setDriveUrl(event.target.value);
   };
-
-  // const filter = (event: any) => {
-  //   const query = event.target.value;
-  //   let updatedList: Partial<IDriveInfo>[];
-
-  //   updatedList = [...drivesFilteredList];
-  //   updatedList = updatedList.filter((item: Partial<IDriveInfo>) => {
-  //     return item.name!.toLowerCase().indexOf(query.toLowerCase()) !== -1;
-  //   });
-  //   setDrivesFilteredList(updatedList);
-  //   // if (nameFilteredList.length === 1 && nameFilteredList[0] !== '') {
-  //   //   setDriveName(nameFilteredList[0]);
-  //   //   setDriveUrl('');
-  //   // }
-  // };
 
   return (
     <>
@@ -193,9 +156,6 @@ export function DriveListManagerComponent({ model }: IProps) {
               isName={false}
               value={driveUrl}
               getValue={getValue}
-              // updateSelectedDrives={(value, isName) =>
-              //   updateSelectedDrives(value, isName)
-              // }
             />
 
             <div> Available drives </div>
@@ -203,12 +163,7 @@ export function DriveListManagerComponent({ model }: IProps) {
               isName={true}
               value={searchDrive}
               setValue={setSearchDrive}
-              // filteredList={drivesFilteredList}
-              // filter={filter}
               availableDrives={availableDrives}
-              // updateSelectedDrives={(value, isName) =>
-              //   // updateSelectedDrives(value, isName)
-              // }
               model={model}
             />
           </div>

--- a/src/plugins/drivelistmanager.tsx
+++ b/src/plugins/drivelistmanager.tsx
@@ -40,7 +40,11 @@ export function DriveInputComponent({
           placeholder="Enter drive name"
           value={value}
         />
-        <Button className="input-add-drive-button" onClick={onSubmit}>
+        <Button
+          className="input-add-drive-button"
+          onClick={onSubmit}
+          title="Add public drive"
+        >
           add
         </Button>
       </div>
@@ -86,6 +90,7 @@ export function DriveSearchListComponent(props: ISearchListProps) {
                       await includeDrive(drive.name!);
                       await props.model.refresh();
                     }}
+                    title="Add drive"
                   >
                     <addIcon.react
                       tag="span"
@@ -124,6 +129,7 @@ export function DriveDataGridComponent(props: IDriveDataGridProps) {
                   await excludeDrive(drive.name!);
                   await props.model.refresh();
                 }}
+                title="Remove drive"
               >
                 <removeIcon.react
                   tag="span"

--- a/src/plugins/drivelistmanager.tsx
+++ b/src/plugins/drivelistmanager.tsx
@@ -11,6 +11,7 @@ import { useState } from 'react';
 import { IDriveInfo } from '../token';
 import { getDrivesList, getExcludedDrives, includeDrive } from '../requests';
 import { ISignal, Signal } from '@lumino/signaling';
+import { driveBrowserIcon } from '../icons';
 
 interface IProps {
   model: DriveListModel;
@@ -24,11 +25,8 @@ export interface IDriveInputProps {
 export function DriveInputComponent(props: IDriveInputProps) {
   return (
     <div>
-      <div className="row">
-        <div className="column">
-          <Search className="drive-search-input" onInput={props.getValue} />
-        </div>
-        <div className="column"></div>
+      <div className="add-public-drive-section">
+        <Search className="drive-search-input" onInput={props.getValue} />
         <Button className="input-add-drive-button" onClick={() => {}}>
           add
         </Button>
@@ -70,7 +68,7 @@ export function DriveSearchListComponent(props: ISearchListProps) {
               </div>
               <div className="column">
                 <Button
-                  className="search-add-drive-button"
+                  className="input-add-drive-button"
                   onClick={async () => {
                     await includeDrive(drive.name!);
                     await props.model.refresh();
@@ -97,9 +95,10 @@ export function DriveDataGridComponent(props: IDriveDataGridProps) {
           <DataGridCell className="data-grid-cell" grid-column="1">
             <b> name </b>
           </DataGridCell>
-          <DataGridCell className="data-grid-cell" grid-column="2">
+          <DataGridCell className="data-grid-cell-secondary" grid-column="2">
             <b> region </b>
           </DataGridCell>
+          <DataGridCell className="data-grid-cell-button" grid-column="3" />
         </DataGridRow>
 
         {props.drives.map((item, index) => (
@@ -107,8 +106,13 @@ export function DriveDataGridComponent(props: IDriveDataGridProps) {
             <DataGridCell className="data-grid-cell" grid-column="1">
               {item.name}
             </DataGridCell>
-            <DataGridCell className="data-grid-cell" grid-column="2">
+            <DataGridCell className="data-grid-cell-secondary" grid-column="2">
               {item.region}
+            </DataGridCell>
+            <DataGridCell className="data-grid-cell-button" grid-column="3">
+              <Button className="input-add-drive-button" onClick={() => {}}>
+                add
+              </Button>
             </DataGridCell>
           </DataGridRow>
         ))}
@@ -144,40 +148,46 @@ export function DriveListManagerComponent({ model }: IProps) {
   };
 
   return (
-    <>
-      <div className="drive-list-manager">
-        <div>
-          <h3> Managed listed drives </h3>
+    <div className="drive-list-manager">
+      <span className="drives-manager-header">
+        <driveBrowserIcon.react
+          margin="15px 9.5px 0px 0px"
+          height="auto"
+          width="28px"
+        />
+        <div className="drives-manager-header-title">
+          {'Manage listed drives'}
+          <div className="drives-manager-header-info">
+            {'Add or remove drives from the filebrowser.'}
+          </div>
         </div>
-        <div className="row">
-          <div className="column">
-            <div> Enter public drive name</div>
-            <DriveInputComponent
-              isName={false}
-              value={driveUrl}
-              getValue={getValue}
-            />
+      </span>
+      <div className="row">
+        <div className="drives-manager-section">
+          <DriveDataGridComponent drives={selectedDrives} />
+        </div>
 
-            <div> Available drives </div>
-            <DriveSearchListComponent
-              isName={true}
-              value={searchDrive}
-              setValue={setSearchDrive}
-              availableDrives={availableDrives}
-              model={model}
-            />
-          </div>
+        <div className="drives-manager-section">
+          <div> Enter public drive name</div>
+          <DriveInputComponent
+            isName={false}
+            value={driveUrl}
+            getValue={getValue}
+          />
+        </div>
 
-          <div className="column">
-            <div className="jp-custom-datagrid">
-              <label> Listed drives </label>
-              <label> </label>
-              <DriveDataGridComponent drives={selectedDrives} />
-            </div>
-          </div>
+        <div className="drives-manager-section">
+          <div> Available drives </div>
+          <DriveSearchListComponent
+            isName={true}
+            value={searchDrive}
+            setValue={setSearchDrive}
+            availableDrives={availableDrives}
+            model={model}
+          />
         </div>
       </div>
-    </>
+    </div>
   );
 }
 

--- a/src/plugins/drivelistmanager.tsx
+++ b/src/plugins/drivelistmanager.tsx
@@ -9,7 +9,12 @@ import {
 } from '@jupyter/react-components';
 import { useState } from 'react';
 import { IDriveInfo } from '../token';
-import { getDrivesList, getExcludedDrives, includeDrive } from '../requests';
+import {
+  addPublicDrive,
+  getDrivesList,
+  getExcludedDrives,
+  includeDrive
+} from '../requests';
 import { ISignal, Signal } from '@lumino/signaling';
 import { driveBrowserIcon } from '../icons';
 
@@ -22,12 +27,20 @@ export interface IDriveInputProps {
   value: string;
   getValue: (event: any) => void;
 }
+
 export function DriveInputComponent(props: IDriveInputProps) {
   return (
     <div>
       <div className="add-public-drive-section">
-        <Search className="drive-search-input" onInput={props.getValue} />
-        <Button className="input-add-drive-button" onClick={() => {}}>
+        <Search
+          className="drive-search-input"
+          onInput={props.getValue}
+          placeholder="Enter drive name"
+        />
+        <Button
+          className="input-add-drive-button"
+          onClick={() => addPublicDrive(props.value)}
+        >
           add
         </Button>
       </div>
@@ -168,7 +181,7 @@ export function DriveListManagerComponent({ model }: IProps) {
         </div>
 
         <div className="drives-manager-section">
-          <div> Enter public drive name</div>
+          <div className="drives-section-title"> Add public drive</div>
           <DriveInputComponent
             isName={false}
             value={driveUrl}
@@ -177,7 +190,7 @@ export function DriveListManagerComponent({ model }: IProps) {
         </div>
 
         <div className="drives-manager-section">
-          <div> Available drives </div>
+          <div className="drives-section-title"> Browser available drives </div>
           <DriveSearchListComponent
             isName={true}
             value={searchDrive}

--- a/src/plugins/drivelistmanager.tsx
+++ b/src/plugins/drivelistmanager.tsx
@@ -16,7 +16,7 @@ import {
   includeDrive
 } from '../requests';
 import { ISignal, Signal } from '@lumino/signaling';
-import { driveBrowserIcon } from '../icons';
+import { driveBrowserIcon, addIcon } from '../icons';
 
 interface IProps {
   model: DriveListModel;
@@ -87,7 +87,11 @@ export function DriveSearchListComponent(props: ISearchListProps) {
                       await props.model.refresh();
                     }}
                   >
-                    add
+                    <addIcon.react
+                      tag="span"
+                      className="available-drives-icon"
+                      height="18px"
+                    />
                   </Button>
                 </div>
               </li>

--- a/src/plugins/drivelistmanager.tsx
+++ b/src/plugins/drivelistmanager.tsx
@@ -57,43 +57,44 @@ interface ISearchListProps {
 
 export function DriveSearchListComponent(props: ISearchListProps) {
   return (
-    <div className="drive-search-list">
-      <div className="row">
-        <div className="column">
-          <Search
-            className="drive-search-input"
-            onInput={(event: any) => props.setValue(event.target.value)}
-          />
-        </div>
-        <div className="column"></div>
+    <>
+      <Search
+        className="drive-search-input"
+        onInput={(event: any) => props.setValue(event.target.value)}
+        placeholder="Search drive name"
+      />
+      <div className="drive-search-list">
+        {props.availableDrives.length === 0 ? (
+          <div className="drives-manager-header-info">
+            {'No available drives.'}
+          </div>
+        ) : (
+          props.availableDrives
+            .filter(item => {
+              return (
+                item.name!.toLowerCase().indexOf(props.value.toLowerCase()) !==
+                -1
+              );
+            })
+            .map((drive, index) => (
+              <li key={index}>
+                <div className="available-drives-section">
+                  <div>{drive.name} </div>
+                  <Button
+                    className="search-add-drive-button"
+                    onClick={async () => {
+                      await includeDrive(drive.name!);
+                      await props.model.refresh();
+                    }}
+                  >
+                    add
+                  </Button>
+                </div>
+              </li>
+            ))
+        )}
       </div>
-      {props.availableDrives
-        .filter(item => {
-          return (
-            item.name!.toLowerCase().indexOf(props.value.toLowerCase()) !== -1
-          );
-        })
-        .map((drive, index) => (
-          <li key={index}>
-            <div className="row">
-              <div className="column">
-                <div>{drive.name} </div>
-              </div>
-              <div className="column">
-                <Button
-                  className="input-add-drive-button"
-                  onClick={async () => {
-                    await includeDrive(drive.name!);
-                    await props.model.refresh();
-                  }}
-                >
-                  add
-                </Button>
-              </div>
-            </div>
-          </li>
-        ))}
-    </div>
+    </>
   );
 }
 interface IDriveDataGridProps {

--- a/src/plugins/drivelistmanager.tsx
+++ b/src/plugins/drivelistmanager.tsx
@@ -40,13 +40,7 @@ export function DriveInputComponent({
           placeholder="Enter drive name"
           value={value}
         />
-        <Button
-          className="input-add-drive-button"
-          onClick={() => {
-            onSubmit();
-            setPublicDrive('');
-          }}
-        >
+        <Button className="input-add-drive-button" onClick={onSubmit}>
           add
         </Button>
       </div>
@@ -168,10 +162,8 @@ export function DriveListManagerComponent({ model }: IProps) {
   }, [model]);
 
   const onAddedPublicDrive = async () => {
-    console.log(publicDrive);
     await addPublicDrive(publicDrive);
     setPublicDrive('');
-    console.log('publicDrve: ', publicDrive);
     await model.refresh();
   };
 

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -38,6 +38,31 @@ export async function setListingLimit(newLimit: number) {
 }
 
 /**
+ * Exclude drive from being listed inside the DriveBrowser.
+ *
+ * @returns
+ */
+export async function excludeDrive(driveName: string) {
+  await requestAPI<any>('drives/config', 'POST', {
+    exclude_drive_name: driveName
+  });
+
+  data = {
+    name: driveName,
+    path: driveName,
+    last_modified: '',
+    created: '',
+    content: [],
+    format: 'json',
+    mimetype: '',
+    size: 0,
+    writable: true,
+    type: 'directory'
+  };
+  return data;
+}
+
+/**
  * Fetch the list of available drives.
  * @returns The list of available drives.
  */

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -88,6 +88,14 @@ export async function includeDrive(driveName: string) {
 }
 
 /**
+ * Fetch the list of excluded drives from the filebrowser.
+ * @returns The list of excluded drives.
+ */
+export async function getExcludedDrives() {
+  return await requestAPI<IDriveInfo[]>('drives/config', 'GET');
+}
+
+/**
  * Fetch the list of available drives.
  * @returns The list of available drives.
  */

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -63,6 +63,31 @@ export async function excludeDrive(driveName: string) {
 }
 
 /**
+ * Include drive in DriveBrowser listing.
+ *
+ * @returns
+ */
+export async function includeDrive(driveName: string) {
+  await requestAPI<any>('drives/config', 'POST', {
+    include_drive_name: driveName
+  });
+
+  data = {
+    name: driveName,
+    path: driveName,
+    last_modified: '',
+    created: '',
+    content: [],
+    format: 'json',
+    mimetype: '',
+    size: 0,
+    writable: true,
+    type: 'directory'
+  };
+  return data;
+}
+
+/**
  * Fetch the list of available drives.
  * @returns The list of available drives.
  */

--- a/src/token.ts
+++ b/src/token.ts
@@ -16,6 +16,8 @@ export namespace CommandIDs {
   export const createNewNotebook = 'drives:create-new-notebook';
   export const rename = 'drives:rename';
   export const copyPath = 'drives:copy-path';
+  export const excludeDrive = 'drives:exclude-drive';
+  export const includeDrive = 'drives:include-drive';
 }
 
 /**

--- a/style/addIcon.svg
+++ b/style/addIcon.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 -960 960 960" width="20px" fill="#FFFFFF"><path d="M444-144v-300H144v-72h300v-300h72v300h300v72H516v300h-72Z" fill="#FFFFFF"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 -960 960 960" width="20px"><path d="M444-144v-300H144v-72h300v-300h72v300h300v72H516v300h-72Z"/></svg>

--- a/style/addIcon.svg
+++ b/style/addIcon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 -960 960 960" width="20px" fill="#FFFFFF"><path d="M444-144v-300H144v-72h300v-300h72v300h300v72H516v300h-72Z" fill="#FFFFFF"/></svg>

--- a/style/base.css
+++ b/style/base.css
@@ -27,18 +27,18 @@ li {
 }
 
 .search-add-drive-button {
-  background-color: var(--md-blue-700);
-  color: white;
-  width: 8px;
-
-  /* height: 1em; */
+  background-color: var(--jp-inverse-layout-color1);
+  width: 50px;
+  height: 20px;
   border-radius: 4px;
+  margin-right: 0;
 }
 
 .input-add-drive-button {
   width: 50px;
   height: 24px !important;
-  background-color: var(--jp-brand-color1);
+  background-color: var(--jp-inverse-layout-color1);
+  color: white !important;
   text-align: center;
   color: white;
   border-radius: 4px;
@@ -136,9 +136,24 @@ li {
 
 .available-drives-section {
   display: flex;
-  width: 370px;
+  width: 375px;
   height: 24px;
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
+  border-radius: 4px;
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+.available-drives-section:hover {
+  background-color: var(--md-blue-grey-100);
+}
+
+.available-drives-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  fill: var(--jp-ui-inverse-font-color0) !important;
+  color: var(--jp-ui-inverse-font-color0) !important;
 }

--- a/style/base.css
+++ b/style/base.css
@@ -95,6 +95,7 @@ li {
   flex-direction: row;
   align-items: center;
   margin-left: 10px;
+  margin-bottom: 6px;
 }
 
 .drives-manager-header-title {

--- a/style/base.css
+++ b/style/base.css
@@ -40,7 +40,6 @@ li {
   background-color: var(--jp-inverse-layout-color1);
   color: white !important;
   text-align: center;
-  color: white;
   border-radius: 4px;
 }
 

--- a/style/base.css
+++ b/style/base.css
@@ -11,64 +11,128 @@ li {
   list-style-type: none;
 }
 
-.column {
-  float: left;
-  width: 50%;
-}
+/* .two-column-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.6rem;
+  margin-top: 10px;
+} */
 
 /* Clear floats after the columns */
-.row::after {
+/* .row::after {
   content: '';
   display: table;
   clear: both;
-}
+} */
 
 .drive-search-list {
   width: auto;
 }
 
 .drive-list-manager {
-  width: 800px;
-  height: 800px;
+  min-width: 400px;
+  min-height: 300px;
+  display: flex;
+  flex-direction: column;
 }
 
 .search-add-drive-button {
   background-color: var(--md-blue-700);
   color: white;
 
-  /* width: 8em; */
-  height: 1em;
+  width: 8px;
+  /* height: 1em; */
   border-radius: 4px;
 }
 
 .input-add-drive-button {
-  position: relative;
+  width: 50px;
+  height: 24px !important;
   background-color: var(--jp-brand-color1);
   text-align: center;
   color: white;
-  height: calc(
-    (var(--base-height-multiplier) + var(--density)) * var(--design-unit) * 1px
-  );
   border-radius: 4px;
 }
 
 .drive-search-input {
-  height: 14px;
+  height: 24px !important;
+  width: 100%;
+  flex: 1;
+  justify-content: center;
 }
 
 .drive-data-grid {
-  width: 400px;
+  width: 380px;
+  flex-direction: row;
+  grid-auto-flow: row;
 }
 
 .data-grid-cell {
   text-align: justify;
   height: 2em;
   min-width: 200px;
+  border-right: 5px;
+  border-left: 2px;
+  /* background-color: var(--jp-layout-color2); */
+}
+
+.data-grid-cell-secondary {
+  text-align: justify;
+  height: 2em;
+  min-width: 100px;
   border-right: 2px;
   border-left: 2px;
-  background-color: var(--jp-layout-color2);
+  /* background-color: var(--jp-layout-color2); */
+}
+
+.data-grid-cell-button {
+  text-align: justify;
+  height: 2em;
+  width: 50px;
+  border-right: 2px;
+  border-left: 2px;
+  /* background-color: var(--jp-layout-color2); */
 }
 
 .jp-drive-browser-search-box {
   width: 230px;
+}
+
+.drives-manager-header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-left: 10px;
+}
+
+.drives-manager-header-title {
+  display: flex;
+  flex-direction: column;
+  padding-top: 18px;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.drives-manager-header-info {
+  text-align: left;
+  font-weight: 400;
+  font-size: 0.8rem;
+
+  /* padding-top: 5px; */
+  color: var(--md-blue-grey-600);
+}
+
+.drives-manager-section {
+  width: 380px;
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.add-public-drive-section {
+  display: flex;
+  width: 380px;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.2rem;
 }

--- a/style/base.css
+++ b/style/base.css
@@ -11,23 +11,12 @@ li {
   list-style-type: none;
 }
 
-/* .two-column-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 0.6rem;
-  margin-top: 10px;
-} */
-
-/* Clear floats after the columns */
-
-/* .row::after {
-  content: '';
-  display: table;
-  clear: both;
-} */
-
 .drive-search-list {
-  width: auto;
+  display: flex;
+  width: 380px;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
 }
 
 .drive-list-manager {
@@ -143,4 +132,13 @@ li {
 
 .drives-section-title {
   font-weight: 500;
+}
+
+.available-drives-section {
+  display: flex;
+  width: 370px;
+  height: 24px;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
 }

--- a/style/base.css
+++ b/style/base.css
@@ -19,6 +19,7 @@ li {
 } */
 
 /* Clear floats after the columns */
+
 /* .row::after {
   content: '';
   display: table;
@@ -39,8 +40,8 @@ li {
 .search-add-drive-button {
   background-color: var(--md-blue-700);
   color: white;
-
   width: 8px;
+
   /* height: 1em; */
   border-radius: 4px;
 }
@@ -73,6 +74,7 @@ li {
   min-width: 200px;
   border-right: 5px;
   border-left: 2px;
+
   /* background-color: var(--jp-layout-color2); */
 }
 
@@ -82,6 +84,7 @@ li {
   min-width: 100px;
   border-right: 2px;
   border-left: 2px;
+
   /* background-color: var(--jp-layout-color2); */
 }
 
@@ -91,6 +94,7 @@ li {
   width: 50px;
   border-right: 2px;
   border-left: 2px;
+
   /* background-color: var(--jp-layout-color2); */
 }
 
@@ -135,4 +139,8 @@ li {
   flex-direction: row;
   align-items: center;
   gap: 0.2rem;
+}
+
+.drives-section-title {
+  font-weight: 500;
 }

--- a/style/base.css
+++ b/style/base.css
@@ -62,8 +62,6 @@ li {
   min-width: 200px;
   border-right: 5px;
   border-left: 2px;
-
-  /* background-color: var(--jp-layout-color2); */
 }
 
 .data-grid-cell-secondary {
@@ -72,8 +70,6 @@ li {
   min-width: 100px;
   border-right: 2px;
   border-left: 2px;
-
-  /* background-color: var(--jp-layout-color2); */
 }
 
 .data-grid-cell-button {
@@ -82,8 +78,6 @@ li {
   width: 50px;
   border-right: 2px;
   border-left: 2px;
-
-  /* background-color: var(--jp-layout-color2); */
 }
 
 .jp-drive-browser-search-box {
@@ -110,8 +104,6 @@ li {
   text-align: left;
   font-weight: 400;
   font-size: 0.8rem;
-
-  /* padding-top: 5px; */
   color: var(--md-blue-grey-600);
 }
 

--- a/style/base.css
+++ b/style/base.css
@@ -44,7 +44,7 @@ li {
 }
 
 .drive-search-input {
-  height: 24px !important;
+  height: 20px !important;
   width: 100%;
   flex: 1;
   justify-content: center;

--- a/style/removeIcon.svg
+++ b/style/removeIcon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 -960 960 960" width="20px" fill="#FFFFFF"><path d="M232-444v-72h496v72H232Z"/></svg>

--- a/style/removeIcon.svg
+++ b/style/removeIcon.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 -960 960 960" width="20px" fill="#FFFFFF"><path d="M232-444v-72h496v72H232Z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 -960 960 960" width="20px"><path d="M232-444v-72h496v72H232Z"/></svg>


### PR DESCRIPTION
Add support for including and excluding specific drives from the drivebrowser listing. The functionalities are available in an integrated experience through the listed drives management dialog that can be accessed through the toolbar button.

**Listed drives management dialog**

[Screencast from 24.07.2025 15:36:13.webm](https://github.com/user-attachments/assets/3ea870cb-a70c-469f-8284-6b1518c1ba3e)


**Remove drive command**
The remove drive command is also accessible when on the context menu when right-clicking a specific drive.

<img width="1866" height="1081" alt="Screenshot from 2025-07-24 15-36-46" src="https://github.com/user-attachments/assets/ed702c6f-02dc-4462-984c-3b250975a609" />

