### PR TITLE
Integrate error handling for adding external drive operation

### DIFF
--- a/jupyter_drives/manager.py
+++ b/jupyter_drives/manager.py
@@ -319,7 +319,7 @@ class JupyterDrivesManager():
         except Exception as e:
             raise tornado.web.HTTPError(
             status_code= httpx.codes.BAD_REQUEST,
-            reason= f"The following error occured when mouting the drive: {e}"
+            reason= f"{e}"
             )
 
         return 
@@ -771,7 +771,7 @@ class JupyterDrivesManager():
         except Exception as e:
              raise tornado.web.HTTPError(
             status_code= httpx.codes.BAD_REQUEST,
-            reason=f"The following error occured when retriving the drive location: {e}",
+            reason=f"{e}",
             )
     
         return location

--- a/src/plugins/drivelistmanager.tsx
+++ b/src/plugins/drivelistmanager.tsx
@@ -29,6 +29,7 @@ export interface IDriveInputProps {
   isPublic: boolean;
   setIsPublic: (value: boolean) => void;
   mountError: string;
+  resetMountError: () => void;
 }
 
 export function DriveInputComponent({
@@ -39,7 +40,8 @@ export function DriveInputComponent({
   onSubmit,
   isPublic,
   setIsPublic,
-  mountError
+  mountError,
+  resetMountError
 }: IDriveInputProps) {
   return (
     <div>
@@ -48,6 +50,7 @@ export function DriveInputComponent({
           className="drive-search-input"
           onInput={(event: any) => {
             setPublicDrive(event.target.value);
+            resetMountError();
           }}
           placeholder="Enter drive name"
           value={driveValue}
@@ -72,6 +75,7 @@ export function DriveInputComponent({
             className="drive-region-input"
             onInput={(event: any) => {
               setRegion(event.target.value);
+              resetMountError();
             }}
             placeholder="Region (e.g.: us-east-1)"
             value={regionValue}
@@ -259,6 +263,7 @@ export function DriveListManagerComponent({ model }: IProps) {
             setIsPublic={setIsPublic}
             onSubmit={onAddedPublicDrive}
             mountError={mountError}
+            resetMountError={() => setMountError('')}
           />
         </div>
 

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -73,7 +73,15 @@ export async function mountDrive(
     drive_name: driveName,
     provider: options.provider
   };
-  return await requestAPI<any>('drives', 'POST', body);
+  try {
+    await requestAPI<any>('drives', 'POST', body);
+  } catch (error: any) {
+    return {
+      error: error
+    };
+  }
+
+  return;
 }
 
 /**

--- a/style/base.css
+++ b/style/base.css
@@ -157,3 +157,8 @@ li {
   fill: var(--jp-ui-inverse-font-color0) !important;
   color: var(--jp-ui-inverse-font-color0) !important;
 }
+
+.error {
+  color: var(--md-red-600);
+  font-size: 0.7rem;
+}


### PR DESCRIPTION
Build upon https://github.com/QuantStack/jupyter-drives/pull/93.

Integrate error handling for the drives management dialog, specifically for the adding external drive component. If there is an error while mounting the drive, it will show in red underneath the component. Once the user starts editing the input, the error disappears and, as expected, upon successful operation, the drive appears in the selected drives list.

This ensures a faulty drive won't be added to the list of drives that appear in the filebrowser and later throw errors when trying to view its contents.

<img width="1855" height="1079" alt="image" src="https://github.com/user-attachments/assets/a9e66ff5-ef64-468d-bac9-8d39da4d4cf8" />
