### PR TITLE
Add session context patch to include drive name in path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,15 @@ import { JupyterFrontEndPlugin } from '@jupyterlab/application';
 import {
   driveFileBrowser,
   openDriveDialogPlugin,
-  launcherPlugin
+  launcherPlugin,
+  sessionContextPatch
 } from './plugins';
 
 const plugins: JupyterFrontEndPlugin<any>[] = [
   driveFileBrowser,
   openDriveDialogPlugin,
-  launcherPlugin
+  launcherPlugin,
+  sessionContextPatch
 ];
 
 export default plugins;

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,3 +1,4 @@
 export * from './driveBrowserPlugin';
 export * from './launcherPlugin';
 export * from './driveDialogPlugin';
+export * from './sessionContextPatch';

--- a/src/plugins/sessionContextPatch.ts
+++ b/src/plugins/sessionContextPatch.ts
@@ -1,0 +1,39 @@
+import {
+  JupyterFrontEndPlugin,
+  JupyterFrontEnd
+} from '@jupyterlab/application';
+import { SessionContext } from '@jupyterlab/apputils';
+import {
+  IDocumentManager,
+  IDocumentWidgetOpener
+} from '@jupyterlab/docmanager';
+
+/**
+ * A plugin to patch the session context path so it includes the drive name.
+ * associated with.
+ */
+export const sessionContextPatch: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlite/application-extension:session-context-patch',
+  autoStart: true,
+  requires: [IDocumentManager, IDocumentWidgetOpener],
+  activate: (
+    app: JupyterFrontEnd,
+    docManager: IDocumentManager,
+    widgetOpener: IDocumentWidgetOpener
+  ) => {
+    const contents = app.serviceManager.contents;
+
+    widgetOpener.opened.connect((_, widget) => {
+      const context = docManager.contextForWidget(widget);
+      const driveName = contents.driveName(context?.path ?? '');
+      if (driveName === '') {
+        // do nothing if this is the default drive
+        return;
+      }
+      const sessionContext = widget.context.sessionContext as SessionContext;
+
+      // Path the session context to include the drive name
+      sessionContext['_path'] = context?.path;
+    });
+  }
+};


### PR DESCRIPTION
Fixes #46 

This PR adds a plugin to patch the session context with the drive name in order to reopen documents from the kernels section of the running panel. This is just a temporary solution,  jupyterlab/jupyterlab#15958 should resolve the issue upstream. 

This patch is originally from jupyterlite/jupyterlite#1227

https://github.com/user-attachments/assets/ecbc0244-07bd-45ef-9d06-1903898aa34f

